### PR TITLE
Sven typo fix and wording 

### DIFF
--- a/addons.rst
+++ b/addons.rst
@@ -1,9 +1,9 @@
 ﻿Extend Plone with Add-On Packages
 =================================
 
-* There are more than 2,000 addons for Plone. We will cover only a handfull today.
+* There are more than 2,000 ad-dons for Plone. We will cover only a handful today.
 * Using them can saves a lot of time
-* The success of a project often depends on finding the right addon
+* The success of a project often depends on finding the right ad-don
 * Their use, usefulness, quality and complexity varies a lot
 
 
@@ -20,7 +20,7 @@ How to find add-ons
 
 .. seealso::
 
-   * A talk on finding and managing addons: http://www.youtube.com/watch?v=Sc6NkqaSjqw
+   * A talk on finding and managing ad-dons: http://www.youtube.com/watch?v=Sc6NkqaSjqw
 
 
 Some notable add-ons
@@ -36,7 +36,7 @@ Some notable add-ons
   UI to create complex landing-pages
 
 `collective.geo <http://collectivegeo.readthedocs.org/en/latest/>`_
-  Flexible bundle of addons to georeference content and display in maps
+  Flexible bundle of ad-dons to georeference content and display in maps
 
 `collective.mailchimp <https://pypi.python.org/pypi/collective.mailchimp>`_
   Allows visitors to subscribe to mailchimp newsletters
@@ -82,7 +82,7 @@ Look at ``buildout.cfg`` file in ``/vagrant/buildout``.
 
 In the section ``[instance]`` there is a variable called ``eggs``, which has a list of *eggs* as a value. Add the following eggs:
 
-We already have added the addons that we will use now:
+We already have added the ad-dons that we will use now:
 
 * ``Products.PloneFormGen``
 * ``collective.plonetruegallery``

--- a/api.rst
+++ b/api.rst
@@ -88,7 +88,7 @@ Products.Ienablesettrace
     A option when running buildout that logs all the pulled packages and versions.
 
 Sentry
-    `Sentry <https://github.com/getsentry/sentry>`_ is a error logging application you can host yourself. It aggregarates tracebacks from many sources and (here comes the killer-feature) even the values of variables in the stacktrace. We use it in all our production-sites.
+    `Sentry <https://github.com/getsentry/sentry>`_ is a error logging application you can host yourself. It aggregates tracebacks from many sources and (here comes the killer-feature) even the values of variables in the stacktrace. We use it in all our production-sites.
 
 zopepy
     Buildout can create a python-shell for you that has all the packages from your Plone site in it's python-path. Add the part like this::

--- a/embed.rst
+++ b/embed.rst
@@ -150,7 +150,7 @@ The config for the Workflow is in :file:`profiles/default/workfows/talks_workflo
 
     After clicking on this, only managers and Reviewers can see the Voting functionality.
 
-    Lastly, we add our silly function to autoapprove talks.
+    Lastly, we add our silly function to auto-approve talks.
 
     You quickly end up writing many event handlers, so we put everything into a directory for eventhandlers.
 

--- a/events.rst
+++ b/events.rst
@@ -14,7 +14,7 @@ We forgot something: A list of talks is great especially if you can sort it by y
 
 We need a schedule and for this we need to store the information when a talk will happen.
 
-Luckily the type *Event* is based on reuseable behaviors from the package plone.app.event.
+Luckily the type *Event* is based on reusable behaviors from the package plone.app.event.
 
 In this chapter we will
 

--- a/extending.rst
+++ b/extending.rst
@@ -7,7 +7,7 @@ Zope is extensible and so is Plone.
 
     If you want to install an add-on, you are going to install an Egg — a form of Python package. Eggs consist of Python files together with other needed files like page templates and the like and a bit of Metadata, bundled to a single archive file.
 
-    There is a huge variety of Plone-compatible packages available. Most are listed in the `Python Package Index <https://pypi.python.org/pypi>`_. A more browseable listing is available at the `Plone.org add-on listing <https://plone.org/products/>`_. The source repository for many public Plone add-ons is `the GitHub Collective <https://github.com/collective>`_. You may also create your own packages or maintain custom repositories.
+    There is a huge variety of Plone-compatible packages available. Most are listed in the `Python Package Index <https://pypi.python.org/pypi>`_. A more browse-able listing is available at the `Plone.org add-on listing <https://plone.org/products/>`_. The source repository for many public Plone add-ons is `the GitHub Collective <https://github.com/collective>`_. You may also create your own packages or maintain custom repositories.
 
     Eggs are younger than Zope. Zope needed something like eggs before there were eggs, and the Zope developers wrote their own system. Old, outdated Plone systems contain a lot of code that is not bundled in an egg. Older code did not have metadata to register things, instead you needed a special setup method. We don't need this method but you might see it in other code. It is usually used to register Archetypes code. Archetypes is the old content type system. We use Dexterity.
 
@@ -23,7 +23,7 @@ This depends on what type of extension you want to create.
 
 
     * You can create extensions with new types of objects to add to your Plone site. Usually these are content types.
-    * You can create an extension that changes or extends functionality. For example to change the way Plone displays search results, or to make pictures searchable by adding a converter from jpg to text.
+    * You can create an extension that changes or extends functionality. For example to change the way Plone displays search results, or to make pictures search-able by adding a converter from jpg to text.
 
 
 skin_folders

--- a/thirdparty_behaviors.rst
+++ b/thirdparty_behaviors.rst
@@ -9,9 +9,9 @@ There are a lot of addons in Plone for sliders/banners/teasers. We thought there
 
 .. image:: http://imgs.xkcd.com/comics/standards.png
 
-Like many addons it has not yet been released on pypi but only exists as code on github.
+Like many ad-dons it has not yet been released on pypi but only exists as code on github.
 
-The training-buildout hold a section ``[sources]`` that tells buildout to download a specific addon not from pypi but from some code repositiory (usually github):
+The training-buildout hold a section ``[sources]`` that tells buildout to download a specific ad-don not from pypi but from some code repository (usually github):
 
 .. code-block:: cfg
 
@@ -32,9 +32,9 @@ After adding the source, we need to add the egg to buildout:
 
 And rerun ``./bin/buildout``
 
-* Install the addon
+* Install the ad-don
 * Create a new dexterity-ct ``Banner`` with **only** the behavior ``Banner`` enabled.
 * Create a folder called ``banners``
 * Add two banners into that folder using images taken from http://lorempixel.com/800/150/
 * Add the Behavior ``Slider`` to the default-contenttype ``Page (Document)``
-* Edit the frontpage and link to the new banners.
+* Edit the front-page and link to the new banners.

--- a/timing.rst
+++ b/timing.rst
@@ -1,4 +1,4 @@
-Timtable
+Timetable
 ========
 
 Version 1.2
@@ -57,10 +57,10 @@ Version 1.1
 **pb**  50 min  #6 Configuring and Customising Plone through the web
 **pg**  20 min  #7 Extending Plone
 **++**  60 min  #8 Extend Plone with Add-ons
-**pg**          #8 - How to find addons
-**pg**          #8 - Installing Addons
+**pg**          #8 - How to find ad-dons
+**pg**          #8 - Installing Ad-dons
 **pb**          #8 - PloneFormGen
-**pb**          #8 - Internationalisation
+**pb**          #8 - Internationalization
 **pg**          #8 - collective.plonetruegallery
 **pb**          #8 - plone.app.themeeditor
 **pg**          #8 - export customizations
@@ -77,7 +77,7 @@ Version 1.1
 **pb**  60 min  #18 Views III: A Talk list
 **pb**  15 min  #19 Custom search
 **pg**  20 min  #20 Extending Dexterity-Types with Behaviors
-**pg**  20 min  #21 Ressources
+**pg**  20 min  #21 Resources
 **pg**  20 min  #22 Social behavior
 **++**  30 min  #23 Writing Viewlets
 **pg**  20 min  #24 Deploying your code

--- a/viewlets_1.rst
+++ b/viewlets_1.rst
@@ -175,7 +175,7 @@ Register a viewlet 'number_of_talks' in the footer that is only visible to admin
 
     ``python:context.portal_catalog`` will return the catalog through Acquisition. Be carefull if you want to use path-expressions: ``content/portal_catalog`` calls the catalog (and returns all brains). You need to prevent this by using ``nocall:content/portal_catalog``.
 
-    Relying on Aqcisition is a bad idea. It would be much better to use the helper view ``plone_tools`` from ``plone/app/layout/globals/tools.py`` to get the catalog.
+    Relying on Acquisition is a bad idea. It would be much better to use the helper view ``plone_tools`` from ``plone/app/layout/globals/tools.py`` to get the catalog.
 
     ..  code-block:: html
 

--- a/views_3.rst
+++ b/views_3.rst
@@ -152,7 +152,7 @@ Who can guess what ``brain.title`` will return since the brain has no such attri
 
         Answer: Acquisition will get the attribute from the nearest parent. ``brain.__parent__`` is ``<CatalogTool at /Plone/portal_catalog>``. The attribute ``title`` of the ``portal_catalog`` is 'Indexes all content in the site'.
 
-Acquisition can be harmfull. Brains have no attribute 'getLayout' ``brain.getLayout()``::
+Acquisition can be harmful. Brains have no attribute 'getLayout' ``brain.getLayout()``::
 
     >>> brain.getLayout()
     'folder_listing'
@@ -188,7 +188,7 @@ Calling the catalog without parameters return the whole site::
     >>> portal_catalog()
     [<Products.ZCatalog.Catalog.mybrains object at 0x1085a11f0>, <Products.ZCatalog.Catalog.mybrains object at 0x1085a12c0>, <Products.ZCatalog.Catalog.mybrains object at 0x1085a1328>, <Products.ZCatalog.Catalog.mybrains object at 0x1085a13 ...
 
-.. seealso::
+.. see also::
 
     http://docs.plone.org/develop/plone/searching_and_indexing/query.html
 
@@ -261,7 +261,7 @@ Speed:
     Python-code is faster than code executed in templates. It's also easy to add caching to methods.
 
 DRY:
-    In Python you can reuse methods and easily refactor code. Refactoring TAL usually means having to do big changes in the html-structure which results in uncomprehensible diffs.
+    In Python you can reuse methods and easily re-factor code. Refactoring TAL usually means having to do big changes in the html-structure which results in incomprehensible diffs.
 
 
 The MVC-Schema does not directly apply to Plone but look at it like this:

--- a/zpt.rst
+++ b/zpt.rst
@@ -166,7 +166,7 @@ tal:condition
 
 * If it's true, then the tag is rendered.
 * If it's false then the tag **and all its children** are removed and no longer evaluated.
-* We can reverse the logic by prepending a ``not:`` to the expression.
+* We can reverse the logic by perpending a ``not:`` to the expression.
 
 Let's add another TAL-Attribute to our above example::
 


### PR DESCRIPTION
- fix various typos
- unify words [sometimes there was a word mix]
- use same words as we use on docs.plone.org [add-on] for example