### PR TITLE
Small fixes to Unit 14.

### DIFF
--- a/eggs1.rst
+++ b/eggs1.rst
@@ -5,7 +5,7 @@ Write your own addons to customize Plone
 
 .. sidebar:: Get the code!
 
-    Get the code for this chapter (:doc:`More info <sneak>`) using this command in the buildout-directory:
+    Get the code for this chapter (:doc:`More info <sneak>`) using this command in the buildout directory:
 
     .. code-block:: bash
 
@@ -16,7 +16,7 @@ Write your own addons to customize Plone
 
 In this part you will:
 
-* Create a custom python-package ``ploneconf.site`` to hold all the code
+* Create a custom python package ``ploneconf.site`` to hold all the code
 * Modify buildout to install that package
 
 
@@ -29,13 +29,13 @@ Topics covered:
 Creating the package
 --------------------
 
-Our own code has to be organised as a python-package, also called *egg*. An egg is a zip file or a directory that follows certain conventions. We are going to use `bobtemplates.plone <https://pypi.python.org/pypi/bobtemplates.plone>`_ to create a skeleton project. We only need to fill the holes.
+Our own code has to be organised as a python package, also called *egg*. An egg is a zip file or a directory that follows certain conventions. We are going to use `bobtemplates.plone <https://pypi.python.org/pypi/bobtemplates.plone>`_ to create a skeleton project. We only need to fill in the blanks.
 
 .. warning::
 
     ``bobtemplates.plone`` is still under heavy development. Questions and the package it creates might change significantly until Plone 5 is finished. For this training use the current master at https://github.com/plone/bobtemplates.plone/tree/b09362f
 
-We create and enter the ``src`` directory (*src* is short for *sources*) and call a script called ``mrbob`` from our buildouts bin-directory:
+We create and enter the ``src`` directory (*src* is short for *sources*) and call a script called ``mrbob`` from our buildout's bin directory:
 
 .. code-block:: bash
 
@@ -63,7 +63,7 @@ We have to answer some questions about the addon. We will press :kbd:`Enter` (i.
 
 .. only:: not presentation
 
-    If this is your first egg, this is a very special moment. We are going to create the egg with a script that generates a lot of necessary files. They all are necessary, but sometimes in a subtle way. It takes a while do understand their full meaning. Only last year I learnt and understood why I should have a ``manifest.in`` file. You can get along without one, but trust me, you get along better with a proper manifest file.
+    If this is your first egg, this is a very special moment. We are going to create the egg with a script that generates a lot of necessary files. They all are necessary, but sometimes in a subtle way. It takes a while to understand their full meaning. Only last year I learnt and understood why I should have a ``manifest.in`` file. You can get along without one, but trust me, you get along better with a proper manifest file.
 
 
 .. _eggs1-inspect-label:
@@ -71,35 +71,35 @@ We have to answer some questions about the addon. We will press :kbd:`Enter` (i.
 Inspecting the package
 ----------------------
 
-In ``src`` there is not a new folder ``ploneconf.site`` and in there is the new package. Let's have a look at some of the files:
+In ``src`` there is now a new folder ``ploneconf.site`` and in there is the new package. Let's have a look at some of the files:
 
-bootstrap-buildout.py, buildout.cfg, travis.cfg.,.travis.yml, .coveragerc
+bootstrap-buildout.py, buildout.cfg, travis.cfg, .travis.yml, .coveragerc
     You can ignore these files for now. They are here to create a buildout only for this egg to make testing it easier. Once we start writing tests for this package we will have another look at them.
 
 README.txt, CHANGES, CONTRIBUTORS, docs/
     The documentation, changelog, the list of contributors and the license of your egg goes in there.
 
 setup.py
-    This file configures the package, it's name, dependencies and some metadata like the authors name and email-adress. The dependencies listed here are automatically downloaded when running buildout.
+    This file configures the package, its name, dependencies and some metadata like the author's name and email adress. The dependencies listed here are automatically downloaded when running buildout.
 
 src/ploneconf/site/
-    The package itself lives inside a special folder-stucture. That seems confusing but is necessary for good testability. Our package is a `namespace package <https://www.python.org/dev/peps/pep-0420/>`_ called *ploneconf.site* and because of this there is a folder ``ploneconf`` with a ``__init__.py`` and in there another folder ``site`` and in there finally is our code.
-    From the buildouts perspective our code is in ``<your buildout directory>/src/ploneconf.site/src/ploneconf/site/<real code>``
+    The package itself lives inside a special folder stucture. That seems confusing but is necessary for good testability. Our package is a `namespace package <https://www.python.org/dev/peps/pep-0420/>`_ called *ploneconf.site* and because of this there is a folder ``ploneconf`` with a ``__init__.py`` and in there another folder ``site`` and in there finally is our code.
+    From the buildout's perspective our code is in ``<your buildout directory>/src/ploneconf.site/src/ploneconf/site/<real code>``
 
 
 .. note::
 
-    Unless discussing the buildout we will from now on silently ommit these folders when describing files and assume that ``<your buildout directory>/src/ploneconf.site/src/ploneconf/site/`` is the root of our package!
+    Unless discussing the buildout we will from now on silently omit these folders when describing files and assume that ``<your buildout directory>/src/ploneconf.site/src/ploneconf/site/`` is the root of our package!
 
 
 configure.zcml (src/ploneconf/site/configure.zcml)
-    The phone-book of the packages. By reading it you can find out which functionality is registered though the component architecture.
+    The phone book of the packages. By reading it you can find out which functionality is registered though the component architecture.
 
 setuphandlers.py (src/ploneconf/site/setuphandlers.py)
-    This holds code that is automatically run when installing and uninstallung out addon.
+    This holds code that is automatically run when installing and uninstalling our addon.
 
 interfaces.py (src/ploneconf/site/interfaces.py)
-    Here a browserlayer is defined in a straightforward python-class. We will need it later.
+    Here a browserlayer is defined in a straightforward python class. We will need it later.
 
 testing.py
     This holds the setup for running tests.
@@ -108,10 +108,10 @@ tests/
     This holds the tests.
 
 browser/
-    This directory is a python-module (because it has a ``__init__.py``) and will by convention hold most things that are visible in the browser.
+    This directory is a python package (because it has a ``__init__.py``) and will by convention hold most things that are visible in the browser.
 
 browser/configure.zcml
-    The phonebook if the browser-directory. Here views, resources and overrides are registered.
+    The phonebook of the browser directory. Here views, resources and overrides are registered.
 
 browser/views.py
     xxx
@@ -123,13 +123,13 @@ static/
     A directory that holds static resources (images/css/js). The files in there will be accessible through URLs like ``++resource++ploneconf.site/myawesome.css``
 
 profiles/default/
-    The folder contains the GenericSetup-profile. During the training will put some xml-files there that hold configuration for the site.
+    The folder contains the GenericSetup profile. During the training will put some xml files there that hold configuration for the site.
 
 profiles/default/metadata.xml
-    Version-number and dependencies that are auto-installed when installing out addon.
+    Version number and dependencies that are auto-installed when installing our addon.
 
 ..    profiles/uninstall/
-      This folder holds another GenericSetup-profile. The steps in there are executed on uninstalling.
+      This folder holds another GenericSetup profile. The steps in there are executed on uninstalling.
 
 
 .. _eggs1-include-label:
@@ -184,7 +184,7 @@ Before we can use our new package we have to tell Plone about it. Edit ``buildou
     test-eggs +=
         ploneconf.site [test]
 
-This tells Buildout to add the egg ``ploneconf.site``. Since it is also in the `sources`-section buildout will not try to download it from pypi but will expect it in ``src/ploneconf.site``. *fs* allows you to add packages on the filesystem without a version control system, or with an unsupported one.
+This tells Buildout to add the egg ``ploneconf.site``. Since it is also in the `sources` section buildout will not try to download it from pypi but will expect it in ``src/ploneconf.site``. *fs* allows you to add packages on the filesystem without a version control system, or with an unsupported one.
 
 Now run buildout to reconfigure Plone with the updated configuration:
 


### PR DESCRIPTION
A python *module* is a single .py file, while a folder with a `__init__.py` file in it is a *package*:

https://docs.python.org/3/glossary.html#term-regular-package