### PR TITLE
Fix links, first small step for auto-deploys

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,7 +22,7 @@ Changelog
 - Add spanish translation.
   [macagua]
 
-- Add support for translations on https://www.transifex.com/projects/p/mastering-plone-training/
+- Add support for translations on https://www.transifex.com/plone/mastering-plone-training/
   [macagua]
 
 
@@ -30,7 +30,7 @@ Changelog
 ------------------
 
 - Move sources to https://github.com/plone/training and render
-  at http://plone-training.readthedocs.org/
+  at https://plone-training.readthedocs.org/en/legacy/
   [pbauer]
 
 - Integrate with docs.plone.org and papyrus

--- a/about.rst
+++ b/about.rst
@@ -25,10 +25,10 @@ Previous Trainings
 The Mastering Plone Training was so far held publicly at the following occasions:
 
 * `March 2015, Munich <http://www.starzel.de/leistungen/training/>`_
-* `Plone Conference 2014, Bristol <http://2014.ploneconf.org/training>`_
+* Plone Conference 2014, Bristol 
 * `June 2014, Caracas <https://twitter.com/hellfish2/status/476906131970068480>`_
 * `May 2014, Munich <http://www.starzel.de/blog/mastering-plone>`_
-* `PythonBrasil/Plone Conference 2013, Brasilia <http://2013.pythonbrasil.org.br/program/training/mastering-plone>`_
+* `PythonBrasil/Plone Conference 2013, Brasilia <http://2013.pythonbrasil.org.br/>`_
 * `PyCon DE 2012, Leipzig <https://2012.de.pycon.org/>`_
 * `Plone Conference 2012, Arnheim <http://2012.ploneconf.org/the-event/training/conference-trainings/mastering-plone>`_
 * `PyCon De 2011, Leipzig <http://2011.de.pycon.org/2011/home/>`_
@@ -195,7 +195,7 @@ Things to do before a training (as a trainer)
 Contributing
 ------------
 
-Everyone is **very welcome** to contribute. Minor bugfixes can be pushed direcly in the `repository <https://github.com/plone/training>`_, bigger changes should made as `pull-requests <https://github.com/plone/training/pull/>`_ and discussed previously in tickets.
+Everyone is **very welcome** to contribute. Minor bugfixes can be pushed direcly in the `repository <https://github.com/plone/training>`_, bigger changes should made as `pull-requests <https://github.com/plone/training/pulls/>`_ and discussed previously in tickets.
 
 
 .. _about-licence-label:
@@ -205,7 +205,7 @@ License
 
 The Mastering Plone Training is licensed under a `Creative Commons Attribution 4.0 International License <http://creativecommons.org/licenses/by/4.0/>`_.
 
-Make sure you have filled out a `Contributor Agreement <http://plone.org/foundation/contributors-agreement>`_.
+Make sure you have filled out a `Contributor Agreement <https://plone.org/foundation/contributors-agreement>`_.
 
 If you haven't filled out a Contributor Agreement, you can still contribute. Contact the Documentation team, for instance via the `mailinglist <http://sourceforge.net/p/plone/mailman/plone-docs/>`_ or directly send a mail to plone-docs@lists.sourceforge.net
 Basically, all we need is your written confirmation that you are agreeing your contribution can be under Creative Commons. You can also add in a comment with your pull request "I, <full name>, agree to have this published under Creative Commons 4.0 International BY".

--- a/addons.rst
+++ b/addons.rst
@@ -24,7 +24,7 @@ How to find add-ons
 
 .. seealso::
 
-   * A talk on finding and managing add-ons: http://www.youtube.com/watch?v=Sc6NkqaSjqw
+   * A talk on finding and managing add-ons: https://www.youtube.com/watch?v=Sc6NkqaSjqw
 
 
 .. _add-ons-notable-label:
@@ -69,7 +69,7 @@ Some noteable add-ons
 `collective.behavior.banner <https://github.com/collective/collective.behavior.banner>`_
   Add decorative banners and sliders
 
-`plone.app.multilingual <http://pypi.python.org/pypi/plone.app.multilingual>`_
+`plone.app.multilingual <https://pypi.python.org/pypi/plone.app.multilingual>`_
   Allows multilingual sites by translating content
 
 `Plomino <http://www.plomino.net/>`_
@@ -198,7 +198,7 @@ Plone can run the same site in many different languages.
 
 We're not doing this with the conference site since the *lingua franca* of the Plone community is English.
 
-We would use http://pypi.python.org/pypi/plone.app.multilingual for this. It is the successor of Products.LinguaPlone (which only works with Archetypes).
+We would use https://pypi.python.org/pypi/plone.app.multilingual for this. It is the successor of Products.LinguaPlone (which only works with Archetypes).
 
 .. note::
 

--- a/anatomy.rst
+++ b/anatomy.rst
@@ -33,7 +33,7 @@ Zope2
 
     Jim Fulton thought that this was slightly tedious. So he wrote code to handle requests. He believed that site content is object-oriented and that the URL should somehow point directly into the object hierarchy, so he wrote an object-oriented database, called `ZODB <http://www.zodb.org/en/latest/>`_.
 
-    The ZODB is a fully `ACID <http://en.wikipedia.org/wiki/ACID>`_ compliant database with automatic transactional integrity. It automatically maps traversal in the object hierarchy to URL paths, so there is no need to "wire" objects or database nodes to URLs. This gives Plone its easy SEO-friendly URLs.
+    The ZODB is a fully `ACID <https://en.wikipedia.org/wiki/ACID>`_ compliant database with automatic transactional integrity. It automatically maps traversal in the object hierarchy to URL paths, so there is no need to "wire" objects or database nodes to URLs. This gives Plone its easy SEO-friendly URLs.
 
     Traversal through the object database is security checked at every point via very fine grained access-control lists.
 
@@ -100,7 +100,7 @@ Zope Toolkit / Zope3
 
     .. seealso::
 
-       * http://plone.org/documentation/faq/zope-3-and-plone
+       * https://plone.org/documentation/faq/zope-3-and-plone
 
 
 .. _anatomy-zca-label:

--- a/buildout_1.rst
+++ b/buildout_1.rst
@@ -57,7 +57,7 @@ One example is the section
     recipe = plone.recipe.zope2instance
     user = admin:admin
 
-This uses the python-package `plone.recipe.zope2instance <http://pypi.python.org/pypi/plone.recipe.zope2instance>`_ to create and configure the Zope 2 instance which we use to run Plone. All the lines after ``recipe = xyz`` are the configuration of the specified recipe.
+This uses the python-package `plone.recipe.zope2instance <https://pypi.python.org/pypi/plone.recipe.zope2instance>`_ to create and configure the Zope 2 instance which we use to run Plone. All the lines after ``recipe = xyz`` are the configuration of the specified recipe.
 
 .. seealso::
 

--- a/conf.py
+++ b/conf.py
@@ -40,6 +40,12 @@ extensions = [
     'sphinx.ext.todo',
 ]
 
+
+# Options for the linkcheck builder
+# Ignore localhost
+linkcheck_ignore = [r'http://localhost:\d+/', r'http://localhost:8080\d+/', r'http://localhost:8080', r'http://127.0.0.1:8080']
+linkcheck_anchors = False
+
 # See http://sphinx-doc.org/ext/todo.html#confval-todo_include_todos
 todo_include_todos = True
 

--- a/custom_search.rst
+++ b/custom_search.rst
@@ -17,7 +17,7 @@ If the chapters about views seem complex, the custom search addon shown below mi
 eea.facetednavigation
 ---------------------
 
-* Install `eea.facetednavigation <http://pypi.python.org/pypi/eea.facetednavigation/>`_
+* Install `eea.facetednavigation <https://pypi.python.org/pypi/eea.facetednavigation/>`_
 * Enable faceted navigation on a new folder "Discover talks" by clicking on *actions* > *Enable faceted navigation*
 * Click on the tab *Faceted criteria* to configure it
 
@@ -30,8 +30,8 @@ eea.facetednavigation
 Examples:
 
 * http://www.dipf.de/en/research/projects
-* https://mountaineers.org/learn/find-courses-clinics-seminars
-* http://www.dynajet.de/en/hochdruckreiniger
+* https://mountaineers.org/learn/courses-clinics-seminars
+* https://www.dyna-jet.com/hochdruckreiniger
 
 .. TODO: add custom eea-view using dates
 

--- a/deployment_code.rst
+++ b/deployment_code.rst
@@ -15,7 +15,7 @@ These are a lot of steps, and there are a lot of actions that can go wrong. Luck
 
 There once was a book on python. Among other things, it had a chapter on releasing an egg with sample code. The sample code was about a printer of nested lists. This resulted in a lot of packages to print out nested lists on pypi.
 
-We will avoid this. Everybody, go to `testpypi.python.org <https://testpypi.python.org>`_ and create an account now.
+We will avoid this. Everybody, go to `testpypi.python.org <https://testpypi.python.org/pypi>`_ and create an account now.
 
 Next, copy the pypirc_sample file to ~/.pypirc, modify it to contain your real username and password.
 

--- a/frontpage.rst
+++ b/frontpage.rst
@@ -240,7 +240,7 @@ Calling the macro in python looks like this  ``metal:use-macro="python:context.r
 Twitter
 -------
 
-You might also want to embedd a twitter feed into the page. Luckily twitter makes it easy to do that. Create the appropriate snippet of code at https://twitter.com/settings/widgets/new/search?query=%23ploneconf and paste it in the template wrapped in a ``<div class="col-lg-6">...</div>`` to have the talklist next to the feeds:
+You might also want to embedd a twitter feed into the page. Luckily twitter makes it easy to do that. Please browse to the `twitter docs <https://dev.twitter.com/web/embedded-timelines>`_ and learn how to create the appropriate snippet of code and paste it in the template wrapped in a ``<div class="col-lg-6">...</div>`` to have the talklist next to the feeds:
 
 ..  code-block:: html
 

--- a/ide.rst
+++ b/ide.rst
@@ -18,8 +18,8 @@ People pick editors themselves. Use whatever you are comfortable and productive 
 * `Sublime <http://www.sublimetext.com/>`_
 * `PyCharm <http://www.jetbrains.com/pycharm/>`_
 * `Wing IDE <http://wingide.com/>`_
-* `PyDev <http://pydev.org/>`_ for `Eclipse <http://eclipse.org/>`_
-* `Aptana Studio <http://aptana.com/products/studio3/>`_
+* `PyDev <http://www.pydev.org/>`_ for `Eclipse <http://www.eclipse.org/>`_
+* `Aptana Studio <http://www.aptana.com/products/studio3.html>`_
 * vim
 * emacs
 * `Textmate <http://macromates.com/>`_

--- a/installation.rst
+++ b/installation.rst
@@ -37,7 +37,7 @@ Installing Plone
 * use a Python that comes pre-installed in your operating system (most Linuxes and Mac OS X have one)
 * use the `python buildout <https://github.com/collective/buildout.python>`_
 * building Linux packages
-* `homebrew <http://mxcl.github.com/homebrew>`_ (Mac OS X)
+* `homebrew <http://mxcl.github.io/homebrew/>`_ (Mac OS X)
 * PyWin32 (Windows)
 
 .. only:: not presentation
@@ -87,14 +87,14 @@ You can host Plone...
 * with one of many professional `hosting providers <http://plone.com/providers>`_
 * on a virtual private server
 * on dedicated servers
-* on `heroku <http://heroku.com>`_ you can run Plone for *free* using the `Heroku buildpack for Plone <https://github.com/niteoweb/heroku-buildpack-plone>`_
+* on `heroku <https://www.heroku.com>`_ you can run Plone for *free* using the `Heroku buildpack for Plone <https://github.com/plone/heroku-buildpack-plone>`_
 * in the cloud (e.g. using Amazon EC2 or `Codio.com <http://blog.dbain.com/2014/04/install-plone-in-under-5-minutes-on.html>`_)
 
 .. seealso::
 
     * Plone Installation Requirements: http://docs.plone.org/manage/installing/requirements.html
     * Run Plone on a 5$ plan: http://www.stevemcmahon.com/steves-blog/plone-on-5-a-month
-    * Where to host Plone: http://plone.org/documentation/faq/where-can-i-host-my-plone-site
+    * Where to host Plone: httpsq://plone.org/documentation/faq/where-can-i-host-my-plone-site
 
 
 .. _installation-prod-deploy-label:

--- a/intro.rst
+++ b/intro.rst
@@ -49,7 +49,7 @@ Some technologies and tools we use during the training:
 * For the beginning training:
 
     * `Virtualbox <https://www.virtualbox.org/>`_
-    * `Vagrant <http://www.vagrantup.com/>`_
+    * `Vagrant <https://www.vagrantup.com/>`_
     * `Ubuntu linux <http://www.ubuntu.com/>`_
     * Through-the-web (TTW)
     * `Buildout <http://www.buildout.org/en/latest/>`_
@@ -59,12 +59,12 @@ Some technologies and tools we use during the training:
 * For the advanced chapters:
 
     * `Git <http://git-scm.com/>`_
-    * `Github <http://github.com>`_
-    * `Try Git (Nice introduction to git and github) <https://try.github.io/>`_
+    * `Github <https://github.com>`_
+    * `Try Git (Nice introduction to git and github) <https://try.github.io/levels/1/challenges/1>`_
     * TAL
     * METAL
     * ZCML
-    * `Python <http://python.org>`_
+    * `Python <https://www.python.org>`_
     * Dexterity
     * Viewlets
     * `JQuery <http://jquery.com/>`_
@@ -100,13 +100,12 @@ Other topics are only covered lightly:
 What to expect
 --------------
 
-At the end of the first two days of training, you'll know many of the tools required for Plone installation, integration and configuration. You'll be able to install add-on packages and will know something about the technologies underlying Plone and their histories. You'll be ready to extend your skills via reading books like `Practical Plone <http://www.packtpub.com/practical-plone-3-beginners-guide-to-building-powerful-websites/book>`_ and the `Plone documentation <http://docs.plone.org>`_.
+At the end of the first two days of training, you'll know many of the tools required for Plone installation, integration and configuration. You'll be able to install add-on packages and will know something about the technologies underlying Plone and their histories. You'll be ready to extend your skills via reading books like `Practical Plone <https://www.packtpub.com/web-development/practical-plone-3-beginners-guide-building-powerful-websites>`_ and the `Plone documentation <http://docs.plone.org>`_.
 
 At the end of the second two days, you won't be a complete professional Plone-programmer, but you will know some of the more powerful features of Plone and should be able to construct a more complex website with custom themes and packages. You should also be able to find out where to look for instructions to do tasks we did not cover. You will know most of the core technologies involved in Plone programming.
 
-If you want to become a professional Plone developer or a highly sophisticated Plone integrator you should definitely read `Martin Aspeli's book <http://www.packtpub.com/professional-plone-4-development/book>`_ and then re-read it again while actually doing a complex project.
+If you want to become a professional Plone developer or a highly sophisticated Plone integrator you should definitely read `Martin Aspeli's book <https://www.packtpub.com/web-development/professional-plone-4-development>`_ and then re-read it again while actually doing a complex project.
 
-Most importantly you should practice your skills and not stop here but go forward! One recommended way would be to follow the `todo-app <http://tutorialtodoapp.readthedocs.org/en/latest/>`_.
 
 .. _intro-classroom-protocol:
 
@@ -160,6 +159,6 @@ Follow the training at http://training.plone.org/5
 
 Further Reading
 ---------------
-* `Martin Aspeli: Professional Plone4 Development <http://www.packtpub.com/professional-plone-4-development/book>`_
-* `Practical Plone <http://www.packtpub.com/practical-plone-3-beginners-guide-to-building-powerful-websites/book>`_
+* `Martin Aspeli: Professional Plone4 Development <https://www.packtpub.com/web-development/professional-plone-4-development>`_
+* `Practical Plone <https://www.packtpub.com/web-development/professional-plone-4-development>`_
 * `Zope Page Templates Reference <http://docs.zope.org/zope2/zope2book/AppendixC.html>`_

--- a/plone5.rst
+++ b/plone5.rst
@@ -82,7 +82,7 @@ The resource registry allows you to configure and edit the static resources (js,
 Chameleon template engine
 -------------------------
 
-`Chameleon <https://chameleon.readthedocs.org>`_ is the new rendering engine of Plone 5. It offers may improvements:
+`Chameleon <https://chameleon.readthedocs.org/en/latest/>`_ is the new rendering engine of Plone 5. It offers may improvements:
 
 Old syntax:
 

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -90,7 +90,7 @@ Installing Plone with vagrant
 
 In order not to waste too much time with installing and debugging the differences between systems, we use a virtual machine (Ubuntu 14.04) to run Plone during the training. We rely on Vagrant and VirtualBox to give the same development environment to everyone.
 
-`Vagrant <http://www.vagrantup.com>`_ is a tool for building complete development environments. We use it together with Oracle’s `VirtualBox <https://www.virtualbox.org>`_ to create and manage a virtual environment.
+`Vagrant <https://www.vagrantup.com>`_ is a tool for building complete development environments. We use it together with Oracle’s `VirtualBox <https://www.virtualbox.org>`_ to create and manage a virtual environment.
 
 .. _install-virtualbox:
 

--- a/plone_training_config/what_vagrant_does.rst
+++ b/plone_training_config/what_vagrant_does.rst
@@ -57,7 +57,7 @@ Instead, vagrant now creates our own little Buildout and merely uses the eggs th
 
     $ cp -Rf /home/vagrant/Plone/buildout-cache /home/vagrant
 
-Then we check out our tutorial buildout from http://github.com/collective/training_buildout, switch to the branch 'plone5' and build it.
+Then we check out our tutorial buildout from https://github.com/collective/training_buildout, switch to the branch 'plone5' and build it.
 
 .. code-block:: bash
 

--- a/views_3.rst
+++ b/views_3.rst
@@ -485,7 +485,7 @@ Adding some javascript (collective.js.datatables)
 
 We could improve that table further by using a nice javascript library called "datatables". It might even become part of the Plone core at some point.
 
-Like for many js libraries there is already a python package that does the plone integration for us: ``collective.js.datatables``. Like all python packages you can find it on pypi: http://pypi.python.org/pypi/collective.js.datatables
+Like for many js libraries there is already a python package that does the plone integration for us: ``collective.js.datatables``. Like all python packages you can find it on pypi: https://pypi.python.org/pypi/collective.js.datatables
 
 We already added the add-on to our buildout, you just have to activate it in our template.
 

--- a/zpt.rst
+++ b/zpt.rst
@@ -425,7 +425,7 @@ When an element has multiple TAL attributes, they are executed in this order:
 Plone 5
 -------
 
-Plone 5 uses a new rendering engine called `Chameleon <http://www.pagetemplates.org/>`_. Using the integration layer `five.pt <https://pypi.python.org/pypi/five.pt>`_ it is fully compatible with the normal TAL syntax but offers some additional features:
+Plone 5 uses a new rendering engine called `Chameleon <https://chameleon.readthedocs.org/en/latest/>`_. Using the integration layer `five.pt <https://pypi.python.org/pypi/five.pt>`_ it is fully compatible with the normal TAL syntax but offers some additional features:
 
 You can use ``${...}`` as short-hand for text insertion in pure html effectively making ``tal:content`` and ``tal:attributes`` obsolete. Here are some examples:
 
@@ -963,12 +963,10 @@ There is a lot more about TAL, TALES and METAL that we have not covered. You'll 
 Chameleon
 ---------
 
-Chameleon is the successor of Zope Page Templates, is used in Plone 5 and can be used in Plone 4 as an add-on.
+Chameleon is the successor of Zope Page Templates, it is used in Plone 5.
 
 - Plip for Chameleon: https://dev.plone.org/ticket/12198
-- Homepage: http://www.pagetemplates.org/
-- Addon for Plone 4: `five.pt <https://pypi.python.org/pypi/five.pt>`_
+- Homepage: https://chameleon.readthedocs.org/en/latest/
 
-In Plone 4 uses the default ZPT where some features are missing.
 
 


### PR DESCRIPTION
Changes:

- add config to conf.py to ignore 'local' links
- update/fix broken links
- remove old  Plone 4 parts
- remove tutorialtodoapp links


