### PR TITLE
Separate logs, fix link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ local/
 pip-selfcheck.json
 plone_training_config/training/
 presentation/
+log/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext spellcheck
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -38,6 +38,7 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  spellcheck    to run spellcheck against the documentation (if enabled)"
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -52,7 +53,7 @@ manual: *.rst
 
 presentation: *.rst
 	$(SPHINXBUILD) -b html -t presentation . presentation
-  
+
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
@@ -149,10 +150,17 @@ changes:
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) log/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
+		"or in log/linkcheck/output.txt."
+
+spellcheck:
+	LANGUAGE=$* $(SPHINXBUILD) -b spelling -j 4 $(ALLSPHINXOPTS) log/spellcheck/$*
+	@echo
+	@echo "Spellcheck is finished; look for any errors in the above output " \
+		" or in log/spellcheck/output.txt."
+
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest

--- a/conf.py
+++ b/conf.py
@@ -89,7 +89,7 @@ release = '1.2.5a'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build', 'lib', 'bin', 'include', 'local',
-                    'ploneconf.site_sneak']
+                    'ploneconf.site_sneak', 'log']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -151,7 +151,7 @@ Setup Vagrant to automatically install the current guest additions. You can choo
 
     $ vagrant plugin install vagrant-vbguest
 
-Now download https://raw.githubusercontent.com/plone/training/plone5/plone_training_config.zip and copy its contents into your training directory.
+Now download https://raw.githubusercontent.com/plone/training/master/plone_training_config.zip and copy its contents into your training directory.
 
 .. code-block:: bash
 


### PR DESCRIPTION
- move logs for spell-check and link-check out of build dir
- add log dir to .gitignore
- fix broken link - again - :), there is no Plone 5 branch anymore