### PR TITLE
Improve conf.py in prep. for ci-testing

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -89,7 +89,8 @@ release = '1.2.5a'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build', 'lib', 'bin', 'include', 'local',
-                    'ploneconf.site_sneak', 'log']
+                    'ploneconf.site_sneak', 'log', 'README.rst',
+                    'CHANGES.txt', 'spelling_wordlist.txt']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None


### PR DESCRIPTION
- This improves conf.py in preparation of ci-testing, also it reduces sphinx build warnings/errors, the README is not part of the docs 