### PR TITLE
used name Page instead of Document; fixed error in talk schema

### DIFF
--- a/dexterity.rst
+++ b/dexterity.rst
@@ -204,7 +204,7 @@ Here is the complete xml-schema created by our actions.
         <description>Name (or names) of the speaker</description>
         <title>Speaker</title>
       </field>
-      <field name="email" type="zope.schema.email.Email">
+      <field name="email" type="plone.schema.email.Email">
         <description>Adress of the speaker</description>
         <title>Email</title>
       </field>

--- a/dexterity.rst
+++ b/dexterity.rst
@@ -248,7 +248,7 @@ Exercises
 Exercise 1
 ++++++++++
 
-Modify Documents to allow uploading an image as decoration (like News Items do).
+Modify Pages to allow uploading an image as decoration (like News Items do).
 
 ..  admonition:: Solution
     :class: toggle
@@ -296,7 +296,7 @@ We could use this content type later to convert speakers into Plone users. We co
             <field name="title" type="zope.schema.TextLine">
               <title>Name</title>
             </field>
-            <field name="email" type="zope.schema.email.Email">
+            <field name="email" type="plone.schema.email.Email">
               <title>Email</title>
             </field>
             <field name="homepage" type="zope.schema.URI">


### PR DESCRIPTION
The schema for Talks made reference to zope.schema.email.Email, this should be plone.schema.email.Email.
The term Document is not used in the interface anymore, we call them Pages. I've fixed the reference to documents in Exercise 1.