### PR TITLE
Update vagrant instructions.rst to include BIOS virtualization note.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,8 @@ This changelog is only very rough. For the full changelog please refer to https:
   Bucarest.
   [fulv]
 
+- Update vagrant installation to include BIOS virtualization note.
+  [lbrannon]
 
 1.2.4 (2014-10-03)
 ------------------

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -216,7 +216,7 @@ This takes a **veeeeery loooong time** (between 10 minutes and 1h depending on y
 
         ssh_exchange_identification: read: Connection reset by peer
 
-    The configuration may have stalled out because your computer's BIOS requires virtualization to be enabled. Check with your computer's manufacturer on how to properly enable virtualization. 
+    The configuration may have stalled out because your computer's BIOS requires virtualization to be enabled. Check with your computer's manufacturer on how to properly enable virtualization.  See: https://teamtreehouse.com/community/vagrant-ssh-sshexchangeidentification-read-connection-reset-by-peer
 
 Once Vagrant finishes the provisioning process, you can login to the now running virtual machine.
 

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -208,6 +208,16 @@ This takes a **veeeeery loooong time** (between 10 minutes and 1h depending on y
 
     You can do this multiple times to fix problems, e.g. if your network connection was down and steps could not finish because of this.
 
+.. note::
+
+    If while bringing vagrant up you get an error similar to:
+
+    .. code-block:: bash
+
+        ssh_exchange_identification: read: Connection reset by peer
+
+    The configuration may have stalled out because your computer's BIOS requires virtualization to be enabled. Check with your computer's manufacturer on how to properly enable virtualization. 
+
 Once Vagrant finishes the provisioning process, you can login to the now running virtual machine.
 
 .. code-block:: bash


### PR DESCRIPTION
Had to enable virtualization in my BIOS before vagrant could be brought 'up.'  Added note to instructions.rst for specific case of ssh_exchange_identification resetting.