### PR TITLE
Fix a couple of duplicate labels and an unmatched literal ending

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,8 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 - Editing while reading. Edited Rapido chapter for language and formatting. [jean]
 
+- Fix a couple of duplicate labels, unmatched literal ending, typo [jean]
+
 1.2.4 (2014-10-03)
 ------------------
 

--- a/mastering_plone/about_mastering.rst
+++ b/mastering_plone/about_mastering.rst
@@ -107,7 +107,7 @@ Exercises
 
 Some additional javascript shows hidden solutions for exercises by clicking.
 
-Just perpend the solution with this markup::
+Just prepend the solution with this markup::
 
     ..  admonition:: Solution
         :class: toggle

--- a/mastering_plone/about_mastering.rst
+++ b/mastering_plone/about_mastering.rst
@@ -1,4 +1,4 @@
-.. _about-label:
+.. _about-mastering-label:
 
 About Mastering Plone
 =====================

--- a/mastering_plone/theming.rst
+++ b/mastering_plone/theming.rst
@@ -1,4 +1,4 @@
-.. _theming-label:
+.. _theming-mastering-label:
 
 Theming
 =======

--- a/mosaic.rst
+++ b/mosaic.rst
@@ -215,7 +215,7 @@ In the third tab of this control panel, named "Show/hide content layouts", we ca
 
 In the first tab, named "Content layouts", there is a source editor.
 
-By editing ``manifext.cfg``, we can assign a layout to another content type by changing the ``for = `` line. If we remove this line, the layout is available for any content type.
+By editing ``manifext.cfg``, we can assign a layout to another content type by changing the ``for =`` line. If we remove this line, the layout is available for any content type.
 
 We can also delete the layout section from ``manifest.cfg``, and the layout will be deleted (if we do so, it is recommended to delete its associated HTML file too).
 


### PR DESCRIPTION
Syntastic's Sphinx plugin picked up a couple of duplicate labels and
warned that ``for = `` should be ``for =`` for the closing marker to be
matched.

It doesn't look like either of the labels were being used.