### PR TITLE
Pygments lexer strictness

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -42,6 +42,8 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 - Fix a couple of duplicate labels, unmatched literal ending, typo [jean]
 
+- Fix code blocks that made Pygments lexer choke [jean]
+
 1.2.4 (2014-10-03)
 ------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,8 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 - Editing while reading. Edited Rapido chapter for language and formatting. [jean]
 
+- Fix a couple of duplicate labels, unmatched literal ending, typo [jean]
+
 1.2.4 (2014-10-03)
 ------------------
 

--- a/mastering_plone/about_mastering.rst
+++ b/mastering_plone/about_mastering.rst
@@ -107,7 +107,7 @@ Exercises
 
 Some additional javascript shows hidden solutions for exercises by clicking.
 
-Just perpend the solution with this markup::
+Just prepend the solution with this markup::
 
     ..  admonition:: Solution
         :class: toggle

--- a/mastering_plone/about_mastering.rst
+++ b/mastering_plone/about_mastering.rst
@@ -1,4 +1,4 @@
-.. _about-label:
+.. _about-mastering-label:
 
 About Mastering Plone
 =====================

--- a/mastering_plone/behaviors_2.rst
+++ b/mastering_plone/behaviors_2.rst
@@ -52,16 +52,15 @@ Writing Code
 
 To start, we create a directory :file:`behavior` with an empty :file:`behavior/__init__.py` file.
 
-Next we must, as always, register our zcml.
+Next we must, as always, register our ZCML.
 
-First, add the information that there will be another zcml file in :file:`configure.zcml`
+First, add the information that there will be another ZCML file in :file:`configure.zcml`
 
 
 .. code-block:: xml
     :linenos:
 
-    <configure
-          ...>
+    <configure xmlns="...">
 
       ...
       <include package=".behavior" />

--- a/mastering_plone/eggs1.rst
+++ b/mastering_plone/eggs1.rst
@@ -39,9 +39,7 @@ We create and enter the ``src`` directory (*src* is short for *sources*) and cal
     $ cd src
     $ ../bin/mrbob -O ploneconf.site bobtemplates:plone_addon
 
-We have to answer some questions about the add-on. We will press :kbd:`Enter` (i.e. choosing the default value) for all questions except 3 (where you enter your github username if you have one) and 5 (Plone version), where we enter :kbd:`5.0`.
-
-..  code-block:: bash
+We have to answer some questions about the add-on. We will press :kbd:`Enter` (i.e. choosing the default value) for all questions except 3 (where you enter your github username if you have one) and 5 (Plone version), where we enter :kbd:`5.0`::
 
     --> What kind of package would you like to create? Choose between 'Basic', 'Dexterity', and 'Theme'. [Basic]:
 

--- a/mastering_plone/reusable.rst
+++ b/mastering_plone/reusable.rst
@@ -53,8 +53,7 @@ Let's modify the file :file:`configure.zcml`
     :linenos:
     :emphasize-lines: 16
 
-    <configure
-      ...>
+    <configure xmlns="...">
 
       <includeDependencies package="." />
 

--- a/mastering_plone/theming.rst
+++ b/mastering_plone/theming.rst
@@ -1,4 +1,4 @@
-.. _theming-label:
+.. _theming-mastering-label:
 
 Theming
 =======

--- a/mastering_plone/zpt_2.rst
+++ b/mastering_plone/zpt_2.rst
@@ -149,13 +149,13 @@ The first step to uncovering that secret is line 14 of ``listing_summary.pt``:
 
 That template ``listing.pt`` defines the slot ``entries`` like this:
 
-..  code-block:: html
+..  code-block:: xml
 
     <metal:listingmacro define-macro="listing">
       <tal:results define="batch view/batch">
         <tal:listing condition="batch">
           <div class="entries" metal:define-slot="entries">
-            <tal:repeat="item batch" metal:define-macro="entries">
+            <tal:entries repeat="item batch" metal:define-macro="entries">
               <tal:block tal:define="obj item/getObject;
                                      item_url item/getURL;
                                      item_id item/getId;

--- a/mosaic.rst
+++ b/mosaic.rst
@@ -215,7 +215,7 @@ In the third tab of this control panel, named "Show/hide content layouts", we ca
 
 In the first tab, named "Content layouts", there is a source editor.
 
-By editing ``manifext.cfg``, we can assign a layout to another content type by changing the ``for = `` line. If we remove this line, the layout is available for any content type.
+By editing ``manifext.cfg``, we can assign a layout to another content type by changing the ``for =`` line. If we remove this line, the layout is available for any content type.
 
 We can also delete the layout section from ``manifest.cfg``, and the layout will be deleted (if we do so, it is recommended to delete its associated HTML file too).
 

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -70,8 +70,8 @@ This will take some time and produce a lot of output because it downloads and co
 
 The output should be similar to:
 
-.. code-block:: pypy
-    :emphasize-lines: 10
+.. code-block:: html
+    :emphasize-lines: 9
 
     2015-09-24 15:51:02 INFO ZServer HTTP server started at Thu Sep 24 15:51:02 2015
             Hostname: 0.0.0.0
@@ -231,7 +231,7 @@ You are now logged in as the user vagrant in ``/home/vagrant``. We'll do all ste
 
 Instead we use our own Plone instance during the training. It is in ``/vagrant/buildout/``. Start it in foreground with ``./bin/instance fg``.
 
-.. code-block:: pypy
+.. code-block:: bash
 
     vagrant@training:~$ cd /vagrant/buildout
     vagrant@training:/vagrant/buildout$ ./bin/instance fg

--- a/theming/adv-diazo.rst
+++ b/theming/adv-diazo.rst
@@ -81,7 +81,7 @@ and if ``portal-column-two`` exists, we add ``col-two``.
 
 Now, one can use these markers to define the grid in a semantic way like this:
 
-.. code-block:: css
+.. code-block:: less
 
    body.col-one.col-content.col-two #content-wrapper {
      .make-row();

--- a/theming/creating-customizing-templates.rst
+++ b/theming/creating-customizing-templates.rst
@@ -61,7 +61,7 @@ two blocks:
    <metal:block define-macro="content-core">
    <tal:def tal:define="data nocall:view/data">
 
-     <div class="event clearfix" itemscope itemtype="http://data-vocabulary.org/Event">
+     <div class="event clearfix" itemscope="itemscope" itemtype="http://data-vocabulary.org/Event">
 
        <ul class="hiddenStructure">
          <li><a itemprop="url" class="url" href="" tal:attributes="href data/url" tal:content="data/url">url</a></li>

--- a/theming/theme-package.rst
+++ b/theming/theme-package.rst
@@ -969,7 +969,7 @@ So we extend our theme's ``manifest.cfg`` to declare ``development-css``,
 ``production-css`` and optionally ``tinymce-content-css``, like this:
 
 
-.. code-block:: xml
+.. code-block:: cfg
 
    [theme]
    title = plonetheme.tango
@@ -1351,7 +1351,7 @@ our downloaded theme uses, we change the end of our ``main.less`` like this:
 
 .. code-block:: css
 
-   // ### UTILS ###
+   // UTILS 
 
    // import bootstrap variables from Plone -->
    @import "@{bootstrap-variables}";
@@ -1365,7 +1365,7 @@ our downloaded theme uses, we change the end of our ``main.less`` like this:
    @import "../bower_components/bootstrap/less/navbar.less";
    @import "../bower_components/bootstrap/less/carousel.less";
 
-   // ### END OF UTILS ###
+   // END OF UTILS 
 
 
    // include theme css as less
@@ -1381,7 +1381,7 @@ Final CSS customization
 To make our theme look nicer, we add some CSS as follows to our ``custom.less``
 file:
 
-.. code:: css
+.. code:: less
 
    /* Custom LESS file that is included from the main.less file */
 


### PR DESCRIPTION
We sometimes lose syntax highlighting because pygments fails to parse the block. 
Sometimes this is quite right, but sometimes it is overly strict. 
This is especially noticeable for CFG files, where line breaks and comments confuse pygments. 
I fixed some but these remain:

```
.../training/mastering_plone/buildout_1.rst:92: WARNING: Could not lex literal_block as "ini". Highlighting skipped.
.../training/mastering_plone/buildout_1.rst:233: WARNING: Could not lex literal_block as "cfg". Highlighting skipped.
.../training/mastering_plone/buildout_1.rst:269: WARNING: Could not lex literal_block as "cfg". Highlighting skipped.
.../training/mastering_plone/eggs1.rst:133: WARNING: Could not lex literal_block as "cfg". Highlighting skipped.
.../training/mastering_plone/sneak.rst:45: WARNING: Could not lex literal_block as "cfg". Highlighting skipped.
```

In the following, the red highlights things that make pygments fail:

![css-failing](https://cloud.githubusercontent.com/assets/84800/18613899/3700285a-7dae-11e6-94f2-979fb901cc87.png)
Fixed:
![css-passing](https://cloud.githubusercontent.com/assets/84800/18613900/37ed4a36-7dae-11e6-9ae3-9bd1b2b1041d.png)

A `cfg` file:

![ini-failing](https://cloud.githubusercontent.com/assets/84800/18613902/39839fd0-7dae-11e6-8786-e2f9e4832ecc.png)
Fixed:
![ini-passing](https://cloud.githubusercontent.com/assets/84800/18613904/3aa47448-7dae-11e6-8f60-c33c95b6b2af.png)
