### PR TITLE
Apply Sphinx inline directives (file, kbd, Python domain, etc.)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -53,6 +53,8 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 - Exercises for behaviors_2, fix some emphasis [tschorr]
 
+- Fix some typos, apply inline directives: file, Python domain, GUI [jean]
+
 1.2.4 (2014-10-03)
 ------------------
 

--- a/deployment/ansible.rst
+++ b/deployment/ansible.rst
@@ -14,16 +14,16 @@ Installation
 Ansible is usually installed on the orchestrating computer -- typically your desktop or laptop.
 It is a large Python application (though a fraction the size of Plone!) that needs many specific Python packages from the Python Package Index (PyPI).
 
-That makes Ansible a strong candidate for a Python ``virtualenv`` installation
-If you don't have virtualenv installed on your computer, do it now.
+That makes Ansible a strong candidate for a Python :program:`virtualenv` installation
+If you don't have :program:`virtualenv` installed on your computer, do it now.
 
-``virtualenv`` may be installed via an OS package manager, or on a Linux or BSD machine with the command:
+:program:`virtualenv` may be installed via an OS package manager, or on a Linux or BSD machine with the command:
 
 .. code-block:: shell-session
 
     sudo easy_install-2.7 virtualenv
 
-Once you've got ``virtualenv``, use it to create a working directory containing a virtual Python:
+Once you've got :program:`virtualenv`, use it to create a working directory containing a virtual Python:
 
 .. code-block:: shell-session
 
@@ -91,9 +91,9 @@ Connecting to remote machines
 
 To use Ansible to provision a remote server, we have two requirements:
 
-1. We must be able to connect to the remote machine using ``ssh``; and,
+1. We must be able to connect to the remote machine using :command:`ssh`; and,
 
-2. We must be able to issue commands on the remote server as ``root`` (superuser), usually via ``sudo``.
+2. We must be able to issue commands on the remote server as ``root`` (superuser), usually via :command:`sudo`.
 
 You'll need to familiarize yourself with how to fulfill these requirements on the cloud/virtual environment of your choice.
 Examples:
@@ -101,12 +101,12 @@ Examples:
 Using Vagrant/virtualbox
 
     You will initially be able to log in as the "vagrant" user using a private key that's in a file created by Vagrant.
-    The user "vagrant" may issue ``sudo`` commands with no additional password.
+    The user "vagrant" may issue :command:`sudo` commands with no additional password.
 
 Using Linode
 
     You'll set a root password when you create your new machine.
-    If you're willing to use the root user directly, you will not need a ``sudo`` password.
+    If you're willing to use the root user directly, you will not need a :command:`sudo` password.
 
 When setting up a Digital Ocean machine
 
@@ -116,7 +116,7 @@ When setting up a Digital Ocean machine
 AWS
 
     AWS EC2 instances are typically created with a an account named "root" or a short name for the OS, like "ubuntu", that contains your ssh public key as an authorized key.
-    Passwordless ``sudo`` is pre-enabled for that account.
+    Passwordless :command:`sudo` is pre-enabled for that account.
 
 The most important thing is that you know your setup.
 Test that knowledge by trying an ssh login and issuing a superuser command.
@@ -178,9 +178,9 @@ If it doesn't, it's created.
 
 Tasks may also have execution conditions expressed in Python syntax and may iterate over simple data structures.
 
-In addition to tasks, Ansible's basic units are _host_ and _variable_ specifications.
+In addition to tasks, Ansible's basic units are *host* and *variable* specifications.
 
-An Ansible ``playbook`` is a specification of tasks that are executed for specified hosts and variables.
+An Ansible *playbook* is a specification of tasks that are executed for specified hosts and variables.
 All of these specifications are in YAML.
 
 Quick intro to YAML
@@ -275,7 +275,7 @@ Quick intro to Jinja2
 YAML doesn't have any built-in way to read a variable.
 Ansible uses the Jinja2 templating language for this purpose.
 
-A quick example: Let's say we have a variable ``timezone`` containing the target server's desired timezone setting.
+A quick example: Let's say we have a variable :py:data:`timezone` containing the target server's desired timezone setting.
 We can use that variable in a task via Jinja2's double-brace notation: ``{{ timezone }}``.
 
 Jinja2 also supports limited Python expression syntax and can read object properties or mapping key/vaues with a dot notation::

--- a/deployment/customization.rst
+++ b/deployment/customization.rst
@@ -41,7 +41,7 @@ Eggs and versions
 
 You're likely to want to add Python packages to your Plone installation to enable add-on functionality.
 
-Let's say you want to add ``Products.PloneFormGen`` and ``webcouturier.dropdownmenu``.
+Let's say you want to add :py:mod:`Products.PloneFormGen` and :py:mod:`webcouturier.dropdownmenu`.
 Just add to your ``local_configure.yml``:
 
 .. code-block:: yaml
@@ -87,7 +87,7 @@ Even if you use your own buildout, you'll need to make sure that some of the pla
 Running buildout and restarting clients
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-By default, the playbook tries to figure out if ``buildout`` needs to be run.
+By default, the playbook tries to figure out if :command:`buildout` needs to be run.
 If you add an egg, for example, the playbook will run buildout to make the buildout-controlled portions of the installation update.
 
 If you don't want that behavior, change it:

--- a/deployment/in_operation.rst
+++ b/deployment/in_operation.rst
@@ -40,7 +40,7 @@ Use ssh tunnels.
 
 This is a pretty typical login that creates handy tunnels between ports on your local machine with matching haproxy-admin, varnish and haproxy front-end ports on the remote server.
 
-While you're logged in, check out the status of the ``supervisor`` process-control system, which is used to launch your Zope/Plone processes.
+While you're logged in, check out the status of the :program:`supervisor` process-control system, which is used to launch your Zope/Plone processes.
 
 .. code-block:: shell-session
 
@@ -72,7 +72,7 @@ This means that if you need to run ``bin/buildout`` via login, it must be run as
     sudo -u plone_buildout bin/buildout
 
 Typically, you would never start the main ZEO server or its clients directly.
-That's handled via ``supervisorctl``.
+That's handled via :program:`supervisorctl`.
 There's one exception to this rule: the playbook creates a ZEO client named ``client_reserved`` that is not part of the load-balancer pool and is not managed by supervisor.
 The purpose of this extra client is to allow you to handle run scripts or debug starts without affecting the load-balanced client pool.
 It's particularly a good idea to use this mechanism to test an updated buildout:
@@ -90,7 +90,7 @@ Look in your buildout directory for the scripts directory.
 In it, you should find ``restart_clients.sh``.
 (Go ahead and log out if you're still connected.)
 
-This script, which needs to be run as the superuser via ``sudo``, is intended to manage hot restarts.
+This script, which needs to be run as the superuser via :program:`sudo`, is intended to manage hot restarts.
 Its general strategy is to run through your ZEO clients, sequentially doing the following:
 
 1. Mark it down for maintenance in haproxy;
@@ -115,7 +115,7 @@ Event logs are rotated at 5MB, access logs at 20MB.
 cron jobs
 `````````
 
-The playbook automatically creates ``cron`` jobs for ZODB backup and packing.
+The playbook automatically creates :command:`cron` jobs for ZODB backup and packing.
 These jobs are run as ``plone_daemon``.
 
 The jobs are run in the early morning in the server's time zone.
@@ -228,13 +228,13 @@ On Debian family Linux, the playbook installs ``fail2ban`` and configures it to 
 Monitoring
 ``````````
 
-``logwatch`` is installed and configured to email daily log summaries to the administrative email address.
+:program:`logwatch` is installed and configured to email daily log summaries to the administrative email address.
 
 
-Unless you prevent it, ``munin-node`` is installed and configured to accept connections from the IP address you designate.
-To make use of it, you'll need to install ``munin`` on a monitoring machine.
+Unless you prevent it, :program:`munin-node` is installed and configured to accept connections from the IP address you designate.
+To make use of it, you'll need to install :program:`munin` on a monitoring machine.
 
-The ``munin-node`` install by the playbook disables many monitors that are unlikely to be useful to a mostly dedicated Plone servers.
+The :program:`munin-node` install by the playbook disables many monitors that are unlikely to be useful to a mostly dedicated Plone servers.
 It also installs a Plone-specific monitor that reports resident memory usage by Plone components.
 
 Changes philosophy

--- a/deployment/maintenance.rst
+++ b/deployment/maintenance.rst
@@ -28,7 +28,7 @@ That virtualenv has its own installation of Ansible.
 That's good, because it protects your playbook against unexpected changes in the global environment -- such as Ansible being updated by the OS update mechanisms.
 
 You may need or wish to update the installation of Ansible in your Virtualenv.
-If so, make sure you use the copy of ``pip`` in your virtualenv.
+If so, make sure you use the copy of :program:`pip` in your virtualenv.
 Then, test running your playbook with your new Ansible.
 
 What belongs to the playbook and what doesn't
@@ -37,10 +37,10 @@ What belongs to the playbook and what doesn't
 The general strategy for playbook changes is to not modify anything that's included with the playbook.
 We've gone to some trouble to make sure that you can make most forseeable setup changes without touching distribution files.
 
-The ``local-configure.yml`` is an example of this strategy.
+The :file:`local-configure.yml` is an example of this strategy.
 It is **not** included with the distribution files.
 It never will be.
-We will also never include an ``inventory.cfg`` file.
+We will also never include an :file:`inventory.cfg` file.
 
 That means that you may safely merge changes from the STABLE branch of https://github.com/plone/ansible-playbook without fear of overwriting those files.
 You may also create new playbooks; just give them different names.
@@ -59,12 +59,12 @@ Make sure you keep your added files when you do so.
 Maintenance strategies -- multiple hosts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``local-configure.yml`` file strategy makes it easy to get going with Plone's playbook fast.
+The :file:`local-configure.yml` file strategy makes it easy to get going with Plone's playbook fast.
 But it breaks down if you wish to maintain multiple, different hosts with the playbook.
 Fortunately, there's an easy way to handle the problem.
 
-Create a ``host_vars`` directory inside your playbook directory (the one containing playbook.yml).
+Create a :file:`host_vars` directory inside your playbook directory (the one containing playbook.yml).
 Now, inside that directory, create one file per target host, each with a name that matches the inventory entry for the host, plus ``.yml``.
 Each of these files should be the same as the local-configure.yml file that would be used if this was a single host.
-Delete the no longer needed ``local-configure.yml`` file.
+Delete the no-longer-needed :file:`local-configure.yml` file.
 

--- a/deployment/playbook_use.rst
+++ b/deployment/playbook_use.rst
@@ -5,14 +5,14 @@ Basic use of the playbook
 Local configuration file
 ````````````````````````
 
-For a quick start, copy one of the ``sample-*.yml`` files to ``local-configure.yml``.
-The ``local-configure.yml`` file is automatically included in the main playbook if it's found.
+For a quick start, copy one of the :file:`sample-*.yml` files to :file:`local-configure.yml`.
+The :file:`local-configure.yml` file is automatically included in the main playbook if it's found.
 
 .. code-block:: shell-session
 
     cp sample-small.yml local-configure.yml
 
-Now, edit the ``local-configure.yml`` file to set some required variables:
+Now, edit the :file:`local-configure.yml` file to set some required variables:
 
 admin_email
 
@@ -46,7 +46,7 @@ Use with Vagrant
 If you've installed Vagrant/Virtualbox, you're ready to test.
 Since Vagrant manages the connection, you don't need to create a inventory file entry.
 
-There is a Vagrant setup file, ``Vagrantfile``, included with the playbook, so you may just open a command-line prompt, make sure your Ansible virtualenv is activated, and type:
+There is a Vagrant setup file, :file:`Vagrantfile`, included with the playbook, so you may just open a command-line prompt, make sure your Ansible virtualenv is activated, and type:
 
 .. code-block:: shell-session
 
@@ -63,7 +63,7 @@ There is a Vagrant setup file, ``Vagrantfile``, included with the playbook, so y
     Having several students simultaneously downloading a virtualbox over wifi or a slow connection is a nightmare.
     Have a plan.
 
-Once you've run ``vagrant up``, running it again will not automatically provision the virtualbox.
+Once you've run :program:`vagrant up`, running it again will not automatically provision the virtualbox.
 In this case, that means that Ansible is not run.
 So, if you change your Ansible configuration, you'll need to use:
 
@@ -89,7 +89,7 @@ An example of an ignored failure::
 Vagrant ports
 !!!!!!!!!!!!!
 
-The Vagrant setup (in ``Vagrantfile``) maps several ports on the guest machine (the virtualbox) to the host box.
+The Vagrant setup (in :file:`Vagrantfile`) maps several ports on the guest machine (the virtualbox) to the host box.
 The general scheme is to forward a host port that is 1000 greater than the guest port.
 For example, the load-balancer monitor port on the guest server is ``1080``.
 On the host machine, that's mapped by ssh tunnel to 2080.
@@ -134,12 +134,12 @@ hostname
 
 login id
 
-    The user id of a system account that is either the superuser (root) or is allowed to use ``sudo`` to issue arbitrary commands as the superuser.
+    The user id of a system account that is either the superuser (root) or is allowed to use :command:`sudo` to issue arbitrary commands as the superuser.
 
 password
 
     If your cloud-hosting company does not set up the user account for ssh-keypair authentication, you'll need a password.
-    Even if your account does allow passwordless login, it may still require a password to run ``sudo``.
+    Even if your account does allow passwordless login, it may still require a password to run :command:`sudo`.
 
     If your cloud-hosting company sets up a root user and password, it's a good practice to login (or use Ansible) to create a new, unprivileged user with sudo rights.
     Cautious sysadmins will also disable root login via ssh.
@@ -150,7 +150,7 @@ connection details
     If ssh is switched to an alternate port, you'll need that port number.
 
 With that information, create an inventory file (if none exists) and create a host entry in it.
-We use ``inventory.cfg`` for an inventory file.
+We use :file:`inventory.cfg` for an inventory file.
 A typical inventory file::
 
     www.mydomain.co.uk ansible_host=192.168.1.1 ansible_user=steve
@@ -162,7 +162,7 @@ An inventory file may have many entries.
 You may run Ansible against one, two, all of the hosts in the inventory file, or against alias groups like "plone-servers".
 See `Ansible's inventory documentation <http://docs.ansible.com/ansible/intro_inventory.html>`_ for information on grouping host entries and for more specialized host settings.
 
-Now, let's make things easier for us going forward by creating an ``ansible.cfg`` file in our playbook directory.
+Now, let's make things easier for us going forward by creating an :file:`ansible.cfg` file in our playbook directory.
 In that text file, specify the location of your inventory file:
 
 .. code-block:: cfg
@@ -215,11 +215,11 @@ If all that works, congratulations, you're ready to use Ansible to provision the
 
     The "become" flag tells Ansible to carry out the action while becoming another user on the remote machine.
     If no user is specified, we become the superuser.
-    If no method is specified, it's done via ``sudo``.
+    If no method is specified, it's done via :command:`sudo`.
 
     You won't often use the ``--become`` flag because the playbooks that need it specify it themselves.
 
-Daignosing ssh connection failures
+Diagnosing ssh connection failures
 ``````````````````````````````````
 
 If Ansible has trouble connecting to the remote host, you're going to get a message like:
@@ -232,7 +232,7 @@ If Ansible has trouble connecting to the remote host, you're going to get a mess
         "unreachable": true
     }
 
-If this happens to you, try adding ``-vvv`` to the ``ansible`` or ``ansible-playbook`` command line.
+If this happens to you, try adding ``-vvv`` to the :program:`ansible` or :program:`ansible-playbook` command line.
 The extra information may -- or may not -- be useful.
 
 The real test is to use a direct ssh login in order to get the ssh error.
@@ -278,8 +278,8 @@ If you wish to use our firewall playbook, just use the command:
 
     ansible-playbook firewall.yml
 
-``firewall.yml`` is just a dispatcher.
-Actual firewall code is in the ``firewalls`` subdirectory and is playform-specific.
+:file:`firewall.yml` is just a dispatcher.
+Actual firewall code is in the :file:`firewalls` subdirectory and is platform-specific.
 ``ufw`` is used for the Debian-family; ``firewalld``
 
 The general firewall strategy is to block everything but the ports for ssh, http, https and munin-node.

--- a/deployment/plone_playbook.rst
+++ b/deployment/plone_playbook.rst
@@ -51,7 +51,7 @@ Roles are basically pre-packaged subroutines with their own default variables.
 Several roles are part of the Plone Ansible Playbook kit and will be present in your initial checkout.
 These include roles that set up the haproxy load balancer, varnish cache, nginx http server, postfix SMTP agent, munin-node monitoring, logwatch log analysis, message-of-the-day and a fancy setup for restarting ZEO clients.
 
-Other roles, including the role that actually sets up Plone, are loaded when you use ``ansible-galaxy`` to fetch the items listed in ``requirements.yml``.
+Other roles, including the role that actually sets up Plone, are loaded when you use ``ansible-galaxy`` to fetch the items listed in :file:`requirements.yml`.
 Except for the Plone server role, these are generally very generic Ansible Galaxy roles that we liked.
 
 Vagrant
@@ -63,12 +63,12 @@ We include a couple of files to help you get started with Vagrant testing.
 Vagrantfile
 
     A Vagrant setup file that will allow you to create guest virtual hosts for any of the platforms we support and will run Ansible as the provisioner with playbook.yml.
-    This currently defaults to building an Trusty box, but you may pick others by naming them on the ``vagrant up`` command line.
+    This currently defaults to building a Trusty box, but you may pick others by naming them on the :command:`vagrant up` command line.
 
 vbox_host.cfg
 
     When you use vagrant commands, vagrant controls the ssh connection.
-    vbox_host.cfg is an Ansible inventory file that should allow you to run your playbook directly (without the ``vagrant`` command) against your guest box.
+    :file:`vbox_host.cfg` is an Ansible inventory file that should allow you to run your playbook directly (without the :command:`vagrant` command) against your guest box.
 
 Sample configurations
 `````````````````````
@@ -113,10 +113,10 @@ The ``sample-medium.yml`` file will give you a starting point.
 Tests
 `````
 
-You'll find a ``tests.py`` program file and a ``tests` directory.
-The ``tests`` directory contains Doctest files to test our sample configurations.
+You'll find a :file:`tests.py` program file and a :file:`tests` directory.
+The :file:`tests` directory contains Doctest files to test our sample configurations.
 You may add your own.
 
-The ``tests.py`` program is a convenience script that will run one or more of the Vagrant boxes against one or more of the Doctest files.
+The :file:`tests.py` program is a convenience script that will run one or more of the Vagrant boxes against one or more of the Doctest files.
 Run it with no command line argument for usage help.
 Or, read the source ;)

--- a/javascript/development-process.rst
+++ b/javascript/development-process.rst
@@ -5,11 +5,11 @@ The JavaScript development process in Plone
 Code style
 ==========
 
-Together with ``plone.api`` we developed `code style guidelines <https://github.com/plone/plone.api/blob/master/docs/contribute/conventions.rst>`_, which we are enforcing now for core Plone development.
+Together with :py:mod:`plone.api` we developed `code style guidelines <https://github.com/plone/plone.api/blob/master/docs/contribute/conventions.rst>`_, which we are enforcing now for core Plone development.
 Finally!
 This makes code so much more readable.
-It currently doesn't cover JavaScript code guidelines, but those were thought of, when Mockup was developed.
-And luckily, similar to PEP 8 and the associated tooling (``pep8``, ``pyflakes``, ``flake8``), JavaScript also has some guidelines - not official, but well respected.
+It currently doesn't cover JavaScript code guidelines, but those were considered when Mockup was developed.
+And luckily, similar to PEP 8 and the associated tooling (:program:`pep8`, :program:`pyflakes`, :program:`flake8`), JavaScript also has some guidelines - not official, but well respected.
 `Douglas Crockford <http://javascript.crockford.com/>`_ - besides of specifying the JSON standard - wrote the well known book "JavaScript the good parts".
 Out of that he developed the code linter `JSLint <http://www.jslint.com/>`_.
 Because this one was too strict, some other people wrote `JSHint <http://jshint.com/>`_.
@@ -81,13 +81,13 @@ Still, you can do many commits to not accidentally loose changes and still commi
 
   git commit --amend -am"my commit message".
 
-Don't forget to also include a change log entry in the ``CHANGES.rst`` file.
+Don't forget to also include a change log entry in the :file:`CHANGES.rst` file.
 
 
 Documentation
 =============
 
-Besides documenting your changes in the ``CHANGES.rst`` file, also include user and developer documentation as appropriate.
+Besides documenting your changes in the :file:`CHANGES.rst` file, also include user and developer documentation as appropriate.
 
 For patterns, the user documentation is included in a comment in the header of the pattern file, as described in :ref:`mockup-writing-documentation`.
 

--- a/javascript/javascript-3-ttw.rst
+++ b/javascript/javascript-3-ttw.rst
@@ -17,7 +17,7 @@ Resource Registries
 
 This is the new tool included in Plone 5.
 From here we will manage everything related to Javascript and CSS resources.
-It can be found right at the bottom of Plone's Control Panel, in the ``Advanced`` section.
+It can be found right at the bottom of Plone's Control Panel, in the :guilabel:`Advanced` section.
 
 .. figure:: _static/resource_registry.png
    :align: center
@@ -47,55 +47,55 @@ The LESS will look like this:
     }
 
 
-* Go to the ``Overrides`` tab
-* Click the ``Add file`` button
-* Name the new file ``++plone++static/custom-links.js``
+* Go to the :guilabel:`Overrides` tab
+* Click the :guilabel:`Add file` button
+* Name the new file :file:`++plone++static/custom-links.js`
 * Paste the contents of the Javascript section into the textarea
-* Click ``Save``
-* Click the ``Add file`` button again
-* Name the new file ``++plone++static/custom-links.less``
+* Click :guilabel:`Save`
+* Click the :guilabel:`Add file` button again
+* Name the new file :file:`++plone++static/custom-links.less`
 * Paste the contents of the CSS section into the textarea
-* Click ``Save``
+* Click :guilabel:`Save`
 
 
 Create the resource
 -------------------
 
-* Go to the ``Registry`` tab
-* Click the ``Add resource`` button
+* Go to the :guilabel:`Registry` tab
+* Click the :guilabel:`Add resource` button
 * Name it ``training-custom-links``
 * Under ``JS`` enter ``++plone++static/custom-links.js``
-* For the ``CSS/LESS`` section, click ``Add``
-* Enter ``++plone++static/custom-links.less``
+* For the :guilabel:`CSS/LESS` section, click :guilabel:`Add`
+* Enter :file:`++plone++static/custom-links.less`
 
 It should look somthing like this:
 
 .. figure:: _static/add_resource.png
    :align: center
 
-* Click ``Save``
+* Click :guilabel:`Save`
 
 
 Create the bundle and wire everything up
 ----------------------------------------
 
-* Go to the ``Registry`` tab
-* Click the ``Add bundle`` button
+* Go to the :guilabel:`Registry` tab
+* Click the :guilabel:`Add bundle` button
 * Name it ``training-custom-bundle``
-* Under ``Resources`` enter ``training-custom-links``
-* For the ``Depends`` section, we'll use ``plone``
-* Make sure ``Enabled`` is checked
+* Under :guilabel:`Resources` enter ``training-custom-links``
+* For the :guilabel:`Depends` section, we'll use ``plone``
+* Make sure :guilabel:`Enabled` is checked
 
 It should look somthing like this:
 
 .. figure:: _static/add_bundle.png
    :align: center
 
-* Click ``Save``
+* Click :guilabel:`Save`
 
 
 Build the bundle
 ----------------
 
 In order for changes to be included, you need to build your bundle.
-For doing this, you just need to click the ``Build`` under the bundle you want to build.
+For doing this, you just need to click the :guilabel:`Build` under the bundle you want to build.

--- a/javascript/javascript-scratchpad.rst
+++ b/javascript/javascript-scratchpad.rst
@@ -9,29 +9,29 @@ General advises
 
 .. note::
 
-    When providing static resources (JS/LESS/CSS) for Plone 5's resource registry, use ``plone.resource`` based resources instead of Zope's browser resources.
-    The latter are cached heavily and you won't get your changes build with zope resources.
+    When providing static resources (JS/Less/CSS) for Plone 5's resource registry, use :py:mod:`plone.resource` based resources instead of Zope's browser resources.
+    The latter are cached heavily and you won't get your changes built with Zope resources.
 
 .. note::
 
     A bundle can depend on another.
     This is mainly used for the order of inclusion in the rendered content.
-    Currently, it doesn't hook in the require js dependency mechanism.
+    Currently, it doesn't hook in the require JavaScript dependency mechanism.
     This means, each bundle gets all their dependencies compiled in, which raise the response payload unnecessarily.
-    To avoid this, add your resources to existing bundles, like the "plone" bundle.
+    To avoid this, add your resources to existing bundles, like the ``plone`` bundle.
 
 .. note::
 
     The mockup grunt infrastructure is build with a convention over configuration approach in mind.
     It's actually very picky about a lot of things:
-    locations of your bundle files, location of your bundle less files, location of your pattern js and less files and the require js ids of those.
-    Bundles have to be named "mockup-bundles-BUNDLENAME", patterns have to be named "mockup-patterns-PATTERNNAME".
+    locations of your bundle files, location of your bundle Less files, location of your pattern JavaScript and Less files and the require JavaScript ids of those.
+    Bundles have to be named ``mockup-bundles-BUNDLENAME``, patterns have to be named ``mockup-patterns-PATTERNNAME``.
 
 .. note::
 
     There is currently no API to build JavaScript and Less resources programmatically after importing them.
     Both build steps need the Client side RequireJS respectively Less compilers.
-    The resources are downloaded to your browser, compiled there and re-upload to the Plone server, where they are stored in ZODB as plone.resource resources.
+    The resources are downloaded to your browser, compiled there and re-upload to the Plone server, where they are stored in ZODB as :py:mod:`plone.resource` resources.
     We can pre-build everything using standard JavaScript and Less development frameworks, e.g. via ``mockup``'s Grunt infrastructure.
 
 

--- a/javascript/mockup.rst
+++ b/javascript/mockup.rst
@@ -8,12 +8,12 @@ An important part of the new UI is a collection of new input widgets, that we ar
 
 For Plone, it was high time to update and modernize its input widgets.
 Not because the new ones look much better, but because they offer a much more comfortable way of entering data.
-To update Plone's widgets was the goal of ``plone.app.widgets``, started by Nathan van Gheem and pushed wide forward by Rok Garbas.
+To update Plone's widgets was the goal of :py:mod:`plone.app.widgets`, started by Nathan van Gheem and pushed wide forward by Rok Garbas.
 Rok forked Patternslib and created the Mockup project.
 Patternslib used a complex configuration syntax parser instead of a simple JSON based approach and the test coverage was not high enough.
 Besides it was fun to create something new, so Mockup was born.
 There were concerns about having two projects with the same goal, so JC Brand took the initiative and brought the two projects back together.
-Where Mockup had a dependency on ``mockup-core`` with a base pattern to extend from, a configuration parser, pattern registry and Grunt infrastructure, this dependency was removed and replaced by a dependency on ``patternslib``.
+Where Mockup had a dependency on :py:mod:`mockup-core` with a base pattern to extend from, a configuration parser, pattern registry and Grunt infrastructure, this dependency was removed and replaced by a dependency on :py:mod:`patternslib`.
 
 Those projects led the foundation to the new way of developing JavaScript in Plone.
 

--- a/javascript/requirejs-modules.rst
+++ b/javascript/requirejs-modules.rst
@@ -4,7 +4,7 @@ RequireJS and JavaScript modules
 
 One of the great new features, Plone 5 gives us, is the ability to define and use JavaScript modules.
 
-Most serious programming languages provide the concept of namespaces and module dependencies, like Python's ``import`` mechanism.
+Most serious programming languages provide the concept of namespaces and module dependencies, like Python's :keyword:`import` mechanism.
 Python code would be unmanageable, if we'd rely on the existence of global variables and objects in our own scripts.
 
 But JavaScript doesn't have any concept for declaring dependencies.
@@ -81,7 +81,7 @@ For example, let's assume a project structure like follows and the ``define`` ex
             |___app/
                   |___/my_module.js
 
-Let's do the RequireJS configuration in ``main.js`` and use that as main entry point also to finally let something happen:
+Let's do the RequireJS configuration in :file:`main.js` and use that as main entry point also to finally let something happen:
 
 .. code-block:: javascript
 

--- a/javascript/training_installation.rst
+++ b/javascript/training_installation.rst
@@ -15,7 +15,8 @@ After that, issue the following command to get the development environment for t
 Installing Mockup
 -----------------
 
-Optionally you can install Mockup. Mockup is already included in the `training_buildout <https://github.com/collective/training_buildout/blob/plone5/buildout.cfg>`_. Uncomment the "mockup" line in ``auto-checkout`` and buildout ``eggs`` section.
+Optionally you can install Mockup. Mockup is already included in the `training_buildout <https://github.com/collective/training_buildout/blob/plone5/buildout.cfg>`_.
+Uncomment the "mockup" lines in the buildout's ``auto-checkout`` and ``eggs`` sections.
 
 After that, run buildout:
 
@@ -25,5 +26,5 @@ After that, run buildout:
 
 .. warning::
 
-    If you are running buildout inside vagrant, always remember to use the vagrant.cfg ``bin/buildout -Nc vagrant.cfg``
+    If you are running buildout inside vagrant, always remember to use specify :file:`vagrant.cfg`: :command:`bin/buildout -Nc vagrant.cfg`
 

--- a/mastering_plone/add-ons.rst
+++ b/mastering_plone/add-ons.rst
@@ -88,11 +88,13 @@ Making the add-on packages available to Zope
 
 First, we must make the add-on packages available to Zope. This means that Zope can import the code. Buildout is responsible for this.
 
-Look at the ``buildout.cfg`` file in ``/vagrant/buildout``.
+Look at the :file:`buildout.cfg` file in :file:`/vagrant/buildout`.
 
 .. note::
 
-    If you're using our Vagrant kit, the Plone configuration is available in a folder that is shared between the host and guest operating systems. Look in your Vagrant install directory for the ``buildout`` folder. You may edit configuration files using your favorite text editor in the host operating system, then switch into your virtual machine to run buildout on the guest operating system.
+    If you're using our Vagrant kit, the Plone configuration is available in a folder that is shared between the host and guest operating systems.
+    Look in your Vagrant install directory for the :file:`buildout` folder.
+    You may edit configuration files using your favorite text editor in the host operating system, then switch into your virtual machine to run buildout on the guest operating system.
 
 In the section ``[instance]`` there is a variable called ``eggs``, which has a list of *eggs* as a value. For example::
 
@@ -101,7 +103,8 @@ In the section ``[instance]`` there is a variable called ``eggs``, which has a l
         Products.PloneFormGen
         plone.app.debugtoolbar
 
-You add an egg by adding a new line containing the package name to the configuration. You must write the egg name indented, this way buildout understands that the current line is part of the last variable and not a new variable.
+You add an egg by adding a new line containing the package name to the configuration.
+You must write the egg name indented: this way, buildout understands that the current line is part of the last variable and not a new variable.
 
 If you add new add-ons here you will have to run buildout and restart the site:
 
@@ -161,7 +164,7 @@ Let's build a registration form:
 
 .. note::
 
-    Need CAPTCHAs? Add the ``collective.recaptcha`` package to your buildout and PFG will have a CAPTCHA field.
+    Need CAPTCHAs? Add the :py:mod:`collective.recaptcha` package to your buildout and PFG will have a CAPTCHA field.
 
     Need encryption? Add GPG encryption to your system, add a GPG configuration for the Plone daemon user that includes a public key for the mail targets, and you'll be able to encrypt email before sending.
 
@@ -176,8 +179,8 @@ By the way, while PloneFormGen is good at what it does, it is not a good model f
 
 .. _add-ons-ptg-label:
 
-Add Photo Gallery with collective.plonetruegallery
---------------------------------------------------
+Add Photo Gallery with :py:mod:`collective.plonetruegallery`
+------------------------------------------------------------
 
 To advertise the conference we want to show some photos showing past conferences and the city where the conference is taking place.
 
@@ -187,7 +190,7 @@ https://pypi.python.org/pypi/collective.plonetruegallery
 
 * Activate the add-on
 * Enable the behavior ``Plone True Gallery`` on the type ``Folder``: http://localhost:8080/Plone/dexterity-types/Folder/@@behaviors
-* Add a folder /the-event/location
+* Add a folder ``/the-event/location``
 * Upload some photos from lorempixel.com
 * Enable the view ``galleryview``
 
@@ -203,7 +206,7 @@ We're not doing this with the conference site since the *lingua franca* of the P
 
 We would use the built-in addon https://pypi.python.org/pypi/plone.app.multilingual for this.
 
-Building a multi-lingual site requires activating ``plone.app.multilingual``, but no add-on is necessary to build a site in only one language. Just select a different site language when creating a Plone site, and all text in the user-interface will be switched to that language.
+Building a multi-lingual site requires activating :py:mod:`plone.app.multilingual`, but no add-on is necessary to build a site in only one language. Just select a different site language when creating a Plone site, and all text in the user-interface will be switched to that language.
 
 
 .. _add-ons-summary-label:
@@ -219,7 +222,9 @@ But:
 * Can we create lists with the most important properties of each talk?
 * Can we allow a jury to vote on talks?
 
-We often have to work with structured data. Up to a degree we can do all this TTW, but at some point we run into barriers. In the next part of the training, we'll teach you how to break through these barriers.
+We often have to work with structured data.
+Up to a degree we can do all this TTW, but at some point we run into barriers.
+In the next part of the training, we'll teach you how to break through these barriers.
 
 
 

--- a/mastering_plone/anatomy.rst
+++ b/mastering_plone/anatomy.rst
@@ -29,9 +29,15 @@ Zope2
 
 .. only:: not presentation
 
-    Before Zope, there usually was an Apache server that would call a script and give the request as an input. The script would then just print HTML to the standard output. Apache returned that to the user. Opening database connections, checking permission constraints, generating valid HTML, configuring caching, interpreting form data and everything else: you have to do it on your own. When the second request comes in, you have to do everything again.
+    Before Zope, there usually was an Apache server that would call a script and give the request as an input.
+    The script would then just print HTML to the standard output.
+    Apache returned that to the user.
+    Opening database connections, checking permission constraints, generating valid HTML, configuring caching, interpreting form data and everything else: you have to do it on your own.
+    When the second request comes in, you have to do everything again.
 
-    Jim Fulton thought that this was slightly tedious. So he wrote code to handle requests. He believed that site content is object-oriented and that the URL should somehow point directly into the object hierarchy, so he wrote an object-oriented database, called `ZODB <http://www.zodb.org/en/latest/>`_.
+    Jim Fulton thought that this was slightly tedious.
+    So he wrote code to handle requests.
+    He believed that site content is object-oriented and that the URL should somehow point directly into the object hierarchy, so he wrote an object-oriented database, called `ZODB <http://www.zodb.org/en/latest/>`_.
 
     The ZODB is a fully `ACID <https://en.wikipedia.org/wiki/ACID>`_ compliant database with automatic transactional integrity. It automatically maps traversal in the object hierarchy to URL paths, so there is no need to "wire" objects or database nodes to URLs. This gives Plone its easy SEO-friendly URLs.
 
@@ -43,7 +49,9 @@ Zope2
 
     This might sound weird, what do I gain with this?
 
-    You can have different data or code depending on your ``context``. Imagine you want to have header images differing for each section of your page, sometimes even differing for a specific subsection of your site. So you define a path header_image and put a header image at the root of your site. If you want a folder with a different header image, you put the header image into this folder.
+    You can have different data or code depending on your :py:obj:`context`. Imagine you want to have header images differing for each section of your page, sometimes even differing for a specific subsection of your site.
+    So you define a path ``header_image`` and put a header image at the root of your site.
+    If you want a folder with a different header image, you put the header image into this folder.
     Please take a minute to let this settle and think about what this allows you to do.
 
     - contact forms with different e-mail addresses per section
@@ -94,7 +102,7 @@ Zope Toolkit / Zope3
     Unfortunately, only few people started to use Zope 3, nobody migrated to Zope 3 because nobody knew how.
 
     But there were many useful things in Zope 3 that people wanted to use in Zope 2, thus the Zope community adapted some parts so that they could use them in Zope 2.
-    Sometimes, a wrapper of some sort was necessary, these usually are being provided by packages from the ``five`` namespace.  (Zope 2 + Zope 3 = `five`)
+    Sometimes, a wrapper of some sort was necessary, these usually are being provided by packages from the :py:mod:`five` namespace.  (Zope 2 + Zope 3 = "five")
 
     To make the history complete, since people stayed on Zope 2, the Zope community renamed Zope 3 to Bluebream, so that people would not think that Zope 3 was the future. It wasn't anymore.
 

--- a/mastering_plone/api.rst
+++ b/mastering_plone/api.rst
@@ -36,8 +36,8 @@ In existing code you'll often encounter methods that don't mean anything to you.
 
 Some of these methods will be replaced by plone.api in the future:
 
-- ``Products.CMFCore.utils.getToolByName`` -> ``api.portal.get_tool``
-- ``zope.component.getMultiAdapter`` -> ``api.content.get_view``
+- :py:meth:`Products.CMFCore.utils.getToolByName` -> :py:meth:`api.portal.get_tool`
+- :py:meth:`zope.component.getMultiAdapter` -> :py:meth:`api.content.get_view`
 
 
 .. _api-portal-tools-label:
@@ -45,22 +45,23 @@ Some of these methods will be replaced by plone.api in the future:
 portal-tools
 ------------
 
-Some parts of Plone are very complex modules in themselves (e.g. the versioning machinery of ``Products.CMFEditions``). Some of them have an api that you will have to learn sooner or later.
+Some parts of Plone are very complex modules in themselves (e.g. the versioning machinery of :py:mod:`Products.CMFEditions`).
+Some of them have an API that you will have to learn sooner or later.
 
 Here are a few examples:
 
 portal_catalog
-    ``unrestrictedSearchResults()`` returns search results without checking if the current user has the permission to access the objects.
+    :py:meth:`unrestrictedSearchResults()` returns search results without checking if the current user has the permission to access the objects.
 
-    ``uniqueValuesFor()`` returns all entries in an index
+    :py:meth:`uniqueValuesFor()` returns all entries in an index
 
 portal_setup
-    ``runAllExportSteps()`` generates a tarball containing artifacts from all export steps.
+    :py:meth:`runAllExportSteps()` generates a tarball containing artifacts from all export steps.
 
 portal_quickinstaller
-    ``isProductInstalled()`` checks if a product is installed.
+    :py:meth:`isProductInstalled()` checks if a product is installed.
 
-Usually the best way to learn about the api of a tool is to look in the ``interfaces.py`` in the respective package and read the docstrings.
+Usually the best way to learn about the api of a tool is to look in the :file:`interfaces.py` in the respective package and read the docstrings.
 
 
 .. _api-debugging-label:
@@ -76,41 +77,42 @@ tracebacks and the log
 pdb
     The python debugger pdb is the single most important tool for us when programming. Just add ``import pdb; pdb.set_trace()`` in your code and debug away!
 
-    Since Plone 5 you can even add it to templates: add ``<?python import pdb; pdb.set_trace() ?>`` to a template and you end up in a pdb shell on calling the template. Look at the variable ``econtext`` to see what might have gone wrong.
+    Since Plone 5 you can even add it to templates: add ``<?python import pdb; pdb.set_trace() ?>`` to a template and you end up in a pdb shell on calling the template. Look at the variable :py:obj:`econtext` to see what might have gone wrong.
 
 ipdb
-    Enhanced pdb with the power of IPython, e.g. tab completion, syntax highlighting, better tracebacks and introspection. It also works nicely with Products.PDBDebugMode.
+    Enhanced pdb with the power of IPython, e.g. tab completion, syntax highlighting, better tracebacks and introspection. It also works nicely with :py:mod:`Products.PDBDebugMode`.
 
 Products.PDBDebugMode
     An add-on that has two killer features.
 
     **Post-mortem debugging**: throws you in a pdb whenever an exception occurs. This way you can find out what is going wrong.
 
-    **pdb view**: simply adding ``/pdb`` to a url drops you in a pdb session with the current context as ``self.context``. From there you can do just about anything.
+    **pdb view**: simply adding ``/pdb`` to a url drops you in a pdb session with the current context as :py:obj:`self.context`. From there you can do just about anything.
 
 Debug mode
-    When starting Plone using ``./bin/instance -O Plone debug`` you'll end up in an interactive debugger.
+    When starting Plone using :command:`./bin/instance -O Plone debug` you'll end up in an interactive debugger.
 
 plone.app.debugtoolbar
-    An add-on that allows you to inspect nearly everything. It even has an interactive console, a tester for TALES-expressions and includs a reload-feature like plone.reload.
+    An add-on that allows you to inspect nearly everything. It even has an interactive console, a tester for TALES-expressions and includs a reload-feature like :py:mod:`plone.reload`.
 
 plone.reload
-    An add-on that allows to reload code that you changed without restarting the site. It is also used by plone.app.debugtoolbar.
+    An add-on that allows to reload code that you changed without restarting the site. It is also used by :py:mod:`plone.app.debugtoolbar`.
 
 Products.PrintingMailHost
     An add-on that prevents Plone from sending mails. Instead, they are logged.
 
 Products.enablesettrace or Products.Ienablesettrace
-    Add-on that allows to use pdb and ipdb in python skin scripts. Very useful when debugging legacy code.
+    Add-on that allows to use pdb and ipdb in Python skin scripts. Very useful when debugging legacy code.
 
 ``verbose-security = on``
-    An option for the recipe *plone.recipe.zope2instance* that logs the detailed reasons why a user might not be authorized to see something.
+    An option for the recipe :py:mod:`plone.recipe.zope2instance` that logs the detailed reasons why a user might not be authorized to see something.
 
-``./bin/buildout annotate``
+:command:`./bin/buildout annotate`
     An option when running buildout that logs all the pulled packages and versions.
 
 Sentry
-    `Sentry <https://github.com/getsentry/sentry>`_ is an error logging application you can host yourself. It aggregates tracebacks from many sources and (here comes the killer feature) even the values of variables in the traceback. We use it in all our production sites.
+    `Sentry <https://github.com/getsentry/sentry>`_ is an error logging application you can host yourself.
+    It aggregates tracebacks from many sources and (here comes the killer feature) even the values of variables in the traceback. We use it in all our production sites.
 
 zopepy
     Buildout can create a python shell for you that has all the packages from your Plone site in its python path. Add the part like this::

--- a/mastering_plone/behaviors_2.rst
+++ b/mastering_plone/behaviors_2.rst
@@ -37,7 +37,7 @@ Using Schema
 
 .. only:: not presentation
 
-    The attribute where we store our data will be declared as a schema field. We mark the field as an omitted field (using schema directive similar to ``read_permission`` or ``widget``), because we are not going to create z3c.form widgets for entering or displaying them. We do provide a schema, because many other packages use the schema information to get knowledge of the relevant fields.
+    The attribute where we store our data will be declared as a schema field. We mark the field as an omitted field (using schema directive similar to ``read_permission`` or ``widget``), because we are not going to create :py:mod:`z3c.form` widgets for entering or displaying them. We do provide a schema, because many other packages use the schema information to get knowledge of the relevant fields.
 
     For example, when files were migrated to blobs, new objects had to be created and every schema field was copied. The code can't know about our field, except if we provide schema information.
 

--- a/mastering_plone/buildout_1.rst
+++ b/mastering_plone/buildout_1.rst
@@ -57,7 +57,7 @@ One example is the section
     recipe = plone.recipe.zope2instance
     user = admin:admin
 
-This uses the python package `plone.recipe.zope2instance <https://pypi.python.org/pypi/plone.recipe.zope2instance>`_ to create and configure the Zope 2 instance which we use to run Plone. All the lines after ``recipe = xyz`` are the configuration of the specified recipe.
+This uses the python package `plone.recipe.zope2instance <https://pypi.python.org/pypi/plone.recipe.zope2instance>`_ to create and configure the Zope 2 instance which we use to run Plone. All the lines after :samp:`recipe = xyz` are the configuration of the specified recipe.
 
 .. seealso::
 
@@ -87,7 +87,7 @@ References
 A real life example
 -------------------
 
-Let us walk through the ``buildout.cfg`` for the training and look at some important variables:
+Let us walk through the :file:`buildout.cfg` for the training and look at some important variables:
 
 .. code-block:: ini
 
@@ -215,7 +215,7 @@ Let us walk through the ``buildout.cfg`` for the training and look at some impor
     ploneconf.site_sneak = git https://github.com/collective/ploneconf.site_sneak.git path=src egg=false branch=plone5
 
 
-When you run ``./bin/buildout`` without any arguments, Buildout will look for this file.
+When you run :command:`./bin/buildout` without any arguments, Buildout will look for this file.
 
 .. only:: not presentation
 
@@ -258,13 +258,13 @@ When you run ``./bin/buildout`` without any arguments, Buildout will look for th
         test-eggs +=
         #    ploneconf.site [test]
 
-    This is the list of eggs that we configure to be available for Zope. These eggs are put in the python path of the script ``bin/instance`` with which we start and stop Plone.
+    This is the list of eggs that we configure to be available for Zope. These eggs are put in the python path of the script :command:`bin/instance` with which we start and stop Plone.
 
-    The egg ``Plone`` is a wrapper without code. Among its dependencies is ``Products.CMFPlone``  which is the egg that is at the center of Plone.
+    The egg ``Plone`` is a wrapper without code. Among its dependencies is :py:mod:`Products.CMFPlone`  which is the egg that is at the center of Plone.
 
     The rest are add-ons we already used or will use later. The last eggs are commented out so they will not be installed by Buildout.
 
-    The file ``versions.cfg`` that is included by the ``extends = ...`` statement holds the version pins:
+    The file :file:`versions.cfg` that is included by the :samp:`extends = ...` statement holds the version pins:
 
     .. code-block:: cfg
 
@@ -281,7 +281,7 @@ When you run ``./bin/buildout`` without any arguments, Buildout will look for th
         Products.PythonField = 1.1.3
         ...
 
-    This is another special section. By default buildout will look for version pins in a section called ``[versions]``. This is why we included the file ``versions.cfg``.
+    This is another special section. By default buildout will look for version pins in a section called ``[versions]``. This is why we included the file :file:`versions.cfg`.
 
 .. _buildout1-mrdeveloper-label:
 
@@ -290,11 +290,11 @@ Hello mr.developer!
 
 .. only:: not presentation
 
-    There are many more important things to know, and we can't go through them all in detail but I want to focus on one specific feature: **mr.developer**
+    There are many more important things to know, and we can't go through them all in detail but I want to focus on one specific feature: :py:mod:`mr.developer`
 
-    With mr.developer you can declare which packages you want to check out from which version control system and which repository URL. You can check out sources from git, svn, bzr, hg and maybe more. Also, you can say that some sources are in your local file system.
+    With :py:mod:`mr.developer` you can declare which packages you want to check out from which version control system and which repository URL. You can check out sources from git, svn, bzr, hg and maybe more. Also, you can say that some sources are in your local file system.
 
-    ``mr.developer`` comes with a command, ``./bin/develop``. You can use it to update your code, to check for changes and so on. You can activate and deactivate your source checkouts. If you develop your extensions in eggs with separate checkouts, which is a good practice, you can plan releases by having all source checkouts deactivated, and only activate them when you write changes that require a new release. You can activate and deactivate eggs via the ``develop`` command or the Buildout configuration. You should always use the Buildout way. Your commit serves as documentation.
+    :py:mod:`mr.developer` comes with a command, :command:`./bin/develop`. You can use it to update your code, to check for changes and so on. You can activate and deactivate your source checkouts. If you develop your extensions in eggs with separate checkouts, which is a good practice, you can plan releases by having all source checkouts deactivated, and only activate them when you write changes that require a new release. You can activate and deactivate eggs via the :command:`develop` command or the Buildout configuration. You should always use the Buildout way. Your commit serves as documentation.
 
 .. _buildout1-extensible-label:
 
@@ -318,13 +318,14 @@ Be McGuyver
 
     Another problem is error handling. Buildout tries to install a weird dependency you do not actually want? Buildout will not tell you where it is coming from.
 
-    If there is a problem, you can always run Buildout with ``-v`` to get more verbose output, sometimes it helps.
+    If there is a problem, you can always run Buildout with :option:`-v` to get more verbose output, sometimes it helps.
 
     .. code-block:: bash
 
         $ ./bin/buildout -v
 
-    If strange egg versions are requested, check the dependencies declaration of your eggs and your version pinnings.  Here is an invaluable shell command that allows you to find all packages that depend on a particular egg and version:
+    If strange egg versions are requested, check the dependencies declaration of your eggs and your version pinnings.
+    Here is an invaluable shell command that allows you to find all packages that depend on a particular egg and version:
 
     .. code-block:: bash
 
@@ -332,7 +333,7 @@ Be McGuyver
 
     Put the name of the egg with a version conflict as the first argument.  Also, change the path to the buildout cache folder according to your installation (the vagrant buildout is assumed in the example).
 
-    Some parts of Buildout interpret egg names case sensitive, others won't. This can result in funny problems.
+    Some parts of Buildout interpret egg names case sensitively, others don't. This can result in funny problems.
 
     Always check out the ordering of your extends, always use the :samp:`annotate` command of Buildout to see if it interprets your configuration differently than you. Restrict yourself to simple Buildout files. You can reference variables from other sections, you can even use a whole section as a template. We learned that this does not work well with complex hierarchies and had to abandon that feature.
 

--- a/mastering_plone/configuring_customizing.rst
+++ b/mastering_plone/configuring_customizing.rst
@@ -192,7 +192,7 @@ These are the links at the bottom of the page:
 We want a new link to legal information, called "Imprint".
 
 * Go to ``site_actions`` (we know that because we checked in ``@@manage-viewlets``)
-* Add a CMF Action ``imprint``
+* Add a CMF Action :guilabel:`imprint`
 * Set URL to ``string:${portal_url}/imprint``
 * Leave *condition* empty
 * Set permission to ``View``
@@ -246,10 +246,10 @@ Change some css
 * Go to ZMI
 * Go to portal_skins
 * Go to plone_styles
-* Go to ``ploneCustom.css``
-* Click ``customize``
+* Go to :file:`ploneCustom.css`
+* Click :guilabel:`customize`
 
-The css you add to this file is instantly active on the site.
+The CSS you add to this file is instantly active on the site.
 
 
 portal_view_customizations

--- a/mastering_plone/dexterity.rst
+++ b/mastering_plone/dexterity.rst
@@ -62,8 +62,8 @@ There are two content frameworks in Plone
 What are the differences?
 
 * Dexterity: New, faster, modular, no dark magic for getters and setters
-* Archetype had magic setter/getter - use ``talk.getAudience()`` for the field ``audience``
-* Dexterity: fields are attributes: ``talk.audience`` instead of ``talk.getAudience()``
+* Archetype had magic setter/getter - use :py:meth:`talk.getAudience()` for the field :py:attr:`audience`
+* Dexterity: fields are attributes: :py:attr:`talk.audience` instead of :py:meth:`talk.getAudience()`
 
 "Through The Web" or TTW, i.e. in the browser, without programming:
 

--- a/mastering_plone/dexterity_2.rst
+++ b/mastering_plone/dexterity_2.rst
@@ -32,9 +32,9 @@ Marker Interfaces
 
 The content type `Talk` is not yet a first class citizen because it does not implement its own interface. Interfaces are like nametags, telling other elements who and what you are and what you can do. A marker interface is like such a nametag. The talks actually have an auto-generated marker interface ``plone.dexterity.schema.generated.Plone_0_talk``.
 
-The problem is that the name of the Plone instance ``Plone`` is part of that interface name. If you now moved these types to a site with another name, code that uses these Interfaces would no longer find the objects in question.
+The problem is that the name of the Plone instance ``Plone`` is part of that interface name. If you now moved these types to a site with another name, code that uses these interfaces would no longer find the objects in question.
 
-To solve this we add a new Interface to ``interfaces.py``:
+To solve this we add a new :py:class:`Interface` to :file:`interfaces.py`:
 
 .. code-block:: python
     :linenos:
@@ -55,14 +55,14 @@ To solve this we add a new Interface to ``interfaces.py``:
         """Marker interface for Talks
         """
 
-``ITalk`` is a marker interface. We can bind Views and Viewlets to content that provide these interfaces. Lets see how we can provide this Interface. There are two solution for this.
+:py:class:`ITalk` is a marker interface. We can bind Views and Viewlets to content that provide these interfaces. Lets see how we can provide this Interface. There are two solutions for this.
 
 1. Let them be instances of a class that implements this Interface.
 2. Register this interface as a behavior and enable it on talks.
 
-The first option has an important drawback: Only new talks would be instances of the new class. We would either have to migrate the existing talks or delete them.
+The first option has an important drawback: only *new* talks would be instances of the new class. We would either have to migrate the existing talks or delete them.
 
-So let's register the interface as a behavior in ``behaviors/configure.zcml``
+So let's register the interface as a behavior in :file:`behaviors/configure.zcml`
 
 .. code-block:: xml
 
@@ -72,7 +72,7 @@ So let's register the interface as a behavior in ``behaviors/configure.zcml``
     provides="..interfaces.ITalk"
     />
 
-And enable it on the type in ``profiles/default/types/talk.xml``
+And enable it on the type in :file:`profiles/default/types/talk.xml`
 
 .. code-block:: xml
     :linenos:
@@ -101,13 +101,13 @@ Then we can safely bind the ``talkview`` to the new marker interface.
       permission="zope2.View"
       />
 
-Now the ``/talkview`` can only be used on objects that implement said interface. We can now also query the catalog for objects providing this interface ``catalog(object_provides="ploneconf.site.interfaces.ITalk")``. The ``talklistview`` and the ``demoview`` do not get this constraint since they are not only used on talks.
+Now the ``/talkview`` can only be used on objects that implement said interface. We can now also query the catalog for objects providing this interface :py:meth:`catalog(object_provides="ploneconf.site.interfaces.ITalk")`. The ``talklistview`` and the ``demoview`` do not get this constraint since they are not only used on talks.
 
 .. note::
 
-    Just for completeness sake, this is what would have to happen for the first option (associating the ITalk interface with a Talk class):
+    Just for completeness sake, this is what would have to happen for the first option (associating the :py:class:`ITalk` interface with a :py:class:`Talk` class):
 
-    * Create a new class that inherits from ``plone.dexterity.content.Container`` and implements the marker interface.
+    * Create a new class that inherits from :py:class:`plone.dexterity.content.Container` and implements the marker interface.
 
       .. code-block:: python
 
@@ -118,7 +118,7 @@ Now the ``/talkview`` can only be used on objects that implement said interface.
           class Talk(Container):
               implements(ITalk)
 
-    * Modify the class for new talks in ``profiles/default/types/talk.xml``
+    * Modify the class for new talks in :file:`profiles/default/types/talk.xml`
 
       .. code-block:: xml
           :linenos:
@@ -144,7 +144,7 @@ We will create an upgrade step that
 * runs the typeinfo step (i.e. loads the GenericSetup configuration stores in ``profiles/default/types.xml`` and ``profiles/default/types/...`` so we don't have to reinstall the add-on to have our changes from above take effect) and
 * cleans up some content that might be scattered around the site in the early stages of creating it. We will move all talks to a folder ``talks`` (unless they already are there).
 
-Upgrade steps are usually registered in their own zcml file. Create ``upgrades.zcml``
+Upgrade steps are usually registered in their own zcml file. Create :file:`upgrades.zcml`
 
 .. code-block:: xml
     :linenos:
@@ -167,19 +167,19 @@ Upgrade steps are usually registered in their own zcml file. Create ``upgrades.z
 
     </configure>
 
-The upgrade step bumps the version number of the GenericSetup profile of ploneconf.site from 1000 to 1001. The version is stored in ``profiles/default/metadata.xml``. Change it to
+The upgrade step bumps the version number of the GenericSetup profile of ploneconf.site from 1000 to 1001. The version is stored in :file:`profiles/default/metadata.xml`. Change it to
 
 ..  code-block:: xml
 
     <version>1001</version>
 
-Include the new ``upgrades.zcml`` in our ``configure.zcml`` by adding:
+Include the new :file:`upgrades.zcml` in our :file:`configure.zcml` by adding:
 
 ..  code-block:: xml
 
     <include file="upgrades.zcml" />
 
-GenericSetup now expects the code as a method ``upgrade_site`` in the file ``upgrades.py``. Let's create it.
+GenericSetup now expects the code as a method :py:meth:`upgrade_site` in the file :file:`upgrades.py`. Let's create it.
 
 ..  code-block:: python
     :linenos:
@@ -242,9 +242,9 @@ On the console you should see logging messages like::
 
 Alternatively you can select which upgrade steps to run like this:
 
-* In the ZMI got to *portal_setup*
-* Go to the tab *Upgrades*
-* Select *ploneconf.site* from the dropdown and click *Choose profile*
+* In the ZMI go to *portal_setup*
+* Go to the tab :guilabel:`Upgrades`
+* Select :guilabel:`ploneconf.site` from the dropdown and click :guilabel:`Choose profile`
 * Run the upgrade step.
 
 .. seealso::
@@ -254,7 +254,7 @@ Alternatively you can select which upgrade steps to run like this:
 
 .. note::
 
-    Upgrading from an older version of Plone to a newer one also runs upgrade steps from the package ``plone.app.upgrade``. You should be able to upgrade a clean site from 2.5 to 5.0 with a click.
+    Upgrading from an older version of Plone to a newer one also runs upgrade steps from the package :py:mod:`plone.app.upgrade`. You should be able to upgrade a clean site from 2.5 to 5.0 with a click.
 
     For an example see the upgrade-step to Plone 5.0a1 https://github.com/plone/plone.app.upgrade/blob/master/plone/app/upgrade/v50/alphas.py#L23
 
@@ -269,7 +269,7 @@ A browserlayer is another such marker interface. Browserlayers allow us to easil
 
 Since we want the features we write only to be available when ploneconf.site actually is installed we can bind them to a browserlayer.
 
-Our package already has a browserlayer (``bobtemplates.plone`` added it). See ``interfaces.py``:
+Our package already has a browserlayer (:py:mod:`bobtemplates.plone` added it). See :file:`interfaces.py`:
 
 ..  code-block:: python
 
@@ -279,7 +279,7 @@ Our package already has a browserlayer (``bobtemplates.plone`` added it). See ``
         """Marker interface that defines a browser layer."""
 
 
-It is enabled by GenericSetup when installing the package since it is registered in ``profiles/default/browserlayer.xml``
+It is enabled by GenericSetup when installing the package since it is registered in :file:`profiles/default/browserlayer.xml`
 
 ..  code-block:: xml
 
@@ -305,7 +305,7 @@ We should bind all views to it. Here is an example using the talkview.
       permission="zope2.View"
       />
 
-Note the relative python path ``..interfaces.IPloneconfSiteLayer``. It is equivalent to the absolute path ``ploneconf.site.interfaces.IPloneconfSiteLayer``.
+Note the relative python path :py:class:`..interfaces.IPloneconfSiteLayer`. It is equivalent to the absolute path :py:class:`ploneconf.site.interfaces.IPloneconfSiteLayer`.
 
 .. seealso::
 
@@ -320,18 +320,19 @@ Do you need to bind the :ref:`viewlets1-social2-label` from the chapter 'Writing
 ..  admonition:: Solution
     :class: toggle
 
-    No, it would make no difference since the viewlet is already bound to the marker interface ``ploneconf.site.behaviors.social.ISocial``.
+    No, it would make no difference since the viewlet is already bound to the marker interface :py:class:`ploneconf.site.behaviors.social.ISocial`.
 
 .. _dexterity2-catalogindex-label:
 
 Add catalog indexes
 -------------------
 
-In the ``talklistview`` we had to wake up all objects to access some of their attributes. That is ok if we don't have many objects and they are light dexterity objects. If we had thousands of objects this might not be a good idea.
+In the ``talklistview`` we had to wake up all objects to access some of their attributes.
+That is OK if we don't have many objects and they are light dexterity objects. If we had thousands of objects this might not be a good idea.
 
 Instead of loading them all into memory we will use catalog indexes to get the data we want to display.
 
-Add a new file ``profiles/default/catalog.xml``
+Add a new file :file:`profiles/default/catalog.xml`
 
 .. code-block:: xml
     :linenos:
@@ -353,7 +354,7 @@ Add a new file ``profiles/default/catalog.xml``
       <column value="speaker" />
     </object>
 
-This adds new indexes for the three fields we want to show in the listing. Note that *audience* is a ``KeywordIndex`` because the field is multi-valued, but we want a separate index entry for every value in an object.
+This adds new indexes for the three fields we want to show in the listing. Note that *audience* is a :py:class:`KeywordIndex` because the field is multi-valued, but we want a separate index entry for every value in an object.
 
 The ``column ..`` entries allow us to display the values of these indexes in the tableview of collections.
 

--- a/mastering_plone/dexterity_3.rst
+++ b/mastering_plone/dexterity_3.rst
@@ -366,7 +366,7 @@ Add the viewlet class in ``browser/viewlets.py``
 
 :py:meth:`_sponsors` is cached for an hour using `plone.memoize <http://docs.plone.org/manage/deploying/performance/decorators.html#timeout-caches>`_. This way we don't need to keep all sponsor objects in memory all the time. But we'd have to wait for up to an hour until changes will be visible.
 
-Instead we'll cache until one of the sponsors is modified by using a callable :py:function:`_sponsors_cachekey` that returns a number that changes when a sponsor is modified.
+Instead we'll cache until one of the sponsors is modified by using a callable :py:func:`_sponsors_cachekey` that returns a number that changes when a sponsor is modified.
 
   ..  code-block:: python
 

--- a/mastering_plone/dexterity_3.rst
+++ b/mastering_plone/dexterity_3.rst
@@ -12,29 +12,31 @@ Dexterity Types III: Python
         cp -R src/ploneconf.site_sneak/chapters/13_dexterity_3_p5/ src/ploneconf.site
 
 
-Without sponsors a conference would be hard to finance plus it is a good opportunity for Plone companies to advertise their services.
+Without sponsors, a conference would be hard to finance! Plus it is a good opportunity for Plone companies to advertise their services.
 
 In this part we will:
 
-* create the content type *sponsor* that has a python schema
+* create the content type *sponsor* that has a Python schema
 * create a viewlet that shows the sponsor logos sorted by sponsoring level
 
 
 The topics we cover are:
 
-* python schema for dexterity
+* Python schema for Dexterity
 * schema hint and directives
 * field permissions
 * image scales
 * caching
 
 
-The python schema
+The Python schema
 -----------------
 
-First we create the schema for the new type. Instead of xml we use python now. Create a new folder ``content`` with an empty ``__init__.py`` in it. We don't need to register that folder in ``configure.zcml`` since we don't need a ``content/configure.zcml`` (at least not yet).
+First we create the schema for the new type. Instead of XML, we use Python now.
+Create a new folder :file:`content` with an empty :file:`__init__.py` in it.
+We don't need to register that folder in :file:`configure.zcml` since we don't need a :file:`content/configure.zcml` (at least not yet).
 
-Now add a new file ``content/sponsor.py``.
+Now add a new file :file:`content/sponsor.py`.
 
 .. code-block:: python
     :linenos:
@@ -101,11 +103,11 @@ Now add a new file ``content/sponsor.py``.
 
 Some things are notable here:
 
-* The fields in the schema are mostly from ``zope.schema``. A reference of available fields is at http://docs.plone.org/external/plone.app.dexterity/docs/reference/fields.html
-* In ``directives.widget(level=RadioFieldWidget)`` we change the default widget for a Choice field from a dropdown to radio-boxes. An incomplete reference of available widgets is at http://docs.plone.org/external/plone.app.dexterity/docs/reference/widgets.html
-* ``LevelVocabulary`` is used to create the options used in the field ``level``. This way we could easily translate the displayed value.
-* ``fieldset('Images', fields=['logo', 'advertisment'])`` moves the two image fields to another tab.
-* ``directives.read_permission(...)`` sets the read and write permission for the field ``notes`` to users who can add new members. Usually this permission is only granted to Site Administrators and Managers. We use it to store information that should not be publicly visible. Please note that ``obj.notes`` is still accessible in templates and python. Only using the widget (like we do in the view later) checks for the permission.
+* The fields in the schema are mostly from :py:mod:`zope.schema`. A reference of available fields is at http://docs.plone.org/external/plone.app.dexterity/docs/reference/fields.html
+* In :samp:`directives.widget(level=RadioFieldWidget)` we change the default widget for a Choice field from a dropdown to radio-boxes. An incomplete reference of available widgets is at http://docs.plone.org/external/plone.app.dexterity/docs/reference/widgets.html
+* :py:class:`LevelVocabulary` is used to create the options used in the field ``level``. This way we could easily translate the displayed value.
+* :samp:`fieldset('Images', fields=['logo', 'advertisement'])` moves the two image fields to another tab.
+* :samp:`directives.read_permission(...)` sets the read and write permission for the field ``notes`` to users who can add new members. Usually this permission is only granted to Site Administrators and Managers. We use it to store information that should not be publicly visible. Please note that :py:attr:`obj.notes` is still accessible in templates and Python. Only using the widget (like we do in the view later) checks for the permission.
 * We use no grok here
 
 ..  seealso::
@@ -188,7 +190,7 @@ After reinstalling our package we can create the new type.
 Exercise 1
 ++++++++++
 
-Sponsors are containers but they don't have to be. Turn them into items by changing their class to ``plone.dexterity.content.Item``.
+Sponsors are containers but they don't have to be. Turn them into items by changing their class to :py:class:`plone.dexterity.content.Item`.
 
 ..  admonition:: Solution
     :class: toggle
@@ -264,7 +266,8 @@ But we could tweak the default view with some css to make it less ugly. Add the 
         </body>
         </html>
 
-    Note how we handle the field with special permissions: ``tal:condition="python: 'notes' in view.w"`` checks if the convenience-dictionary ``w`` provided by the base class ``DefaultView`` holds the widget for the field ``notes``. If the current user does not have the permission ``cmf.ManagePortal`` it will be omitted from the dictionary and get an error since ``notes`` would not be a key in ``w``. By first checking if it's missing we work around that.
+    Note how we handle the field with special permissions: :samp:`tal:condition="python: 'notes' in view.w"` checks if the convenience-dictionary :py:data:`w` (provided by the base class :py:class:`DefaultView`) holds the widget for the field ``notes``.
+    If the current user does not have the permission :py:mod:`cmf.ManagePortal` it will be omitted from the dictionary and get an error since ``notes`` would not be a key in :py:data:`w`. By first checking if it's missing we work around that.
 
 
 The viewlet
@@ -357,13 +360,13 @@ Add the viewlet class in ``browser/viewlets.py``
                 results[level] = level_sponsors
             return results
 
-* ``_sponsors`` returns a list of dictionaries containing all necessary info about sponsors.
-* We create the complete img tag using a custom scale (200x80) using the view ``images`` from plone.namedfile. This actually scales the logos and saves them as new blobs.
-* In ``sponsors`` we return a ordered dictionary of randomized lists of dicts (containing the information on sponsors).
+* :py:meth:`_sponsors` returns a list of dictionaries containing all necessary info about sponsors.
+* We create the complete img tag using a custom scale (200x80) using the view ``images`` from :py:mod:`plone.namedfile.` This actually scales the logos and saves them as new blobs.
+* In :py:meth:`sponsors` we return a ordered dictionary of randomized lists of dicts (containing the information on sponsors).
 
-``_sponsors`` is cached for an hour using `plone.memoize <http://docs.plone.org/manage/deploying/performance/decorators.html#timeout-caches>`_. This way we don't need to keep all sponsor objects in memory all the time. But we'd have to wait for up to an hour until changes will be visible.
+:py:meth:`_sponsors` is cached for an hour using `plone.memoize <http://docs.plone.org/manage/deploying/performance/decorators.html#timeout-caches>`_. This way we don't need to keep all sponsor objects in memory all the time. But we'd have to wait for up to an hour until changes will be visible.
 
-Instead we'll cache until one of the sponsors is modified by using a callable ``_sponsors_cachekey`` that returns a number that changes when a sponsor is modified.
+Instead we'll cache until one of the sponsors is modified by using a callable :py:function:`_sponsors_cachekey` that returns a number that changes when a sponsor is modified.
 
   ..  code-block:: python
 
@@ -389,7 +392,7 @@ Instead we'll cache until one of the sponsors is modified by using a callable ``
 The template for the viewlet
 ----------------------------
 
-Add the template ``browser/templates/sponsors_viewlet.pt``
+Add the template :file:`browser/templates/sponsors_viewlet.pt`
 
 .. code-block:: xml
     :linenos:
@@ -422,7 +425,7 @@ Add the template ``browser/templates/sponsors_viewlet.pt``
         </div>
     </div>
 
-There already is some css in ``browser/static/ploneconf.css`` to make it look ok.
+There already is some CSS in :file:`browser/static/ploneconf.css` to make it look OK.
 
 ..  code-block:: css
 
@@ -441,7 +444,7 @@ There already is some css in ``browser/static/ploneconf.css`` to make it look ok
 Exercise 2
 ++++++++++
 
-Turn the a content type speaker from :ref:`Exercise 2 of the first chapter on dexterity <dexterity1-excercises-label>` into a python-based type.
+Turn the content type Speaker from :ref:`Exercise 2 of the first chapter on dexterity <dexterity1-excercises-label>` into a Python-based type.
 
 Is should hold the following fields:
 
@@ -454,7 +457,7 @@ Is should hold the following fields:
 * irc_name
 * image
 
-Do *not* use the IBasic or IDublinCore behavior to add title and description. Instead add your own field ``title`` and give it the title *Name*.
+Do *not* use the :py:class:`IBasic` or :py:class:`IDublinCore` behavior to add title and description. Instead add your own field ``title`` and give it the title *Name*.
 
 ..  admonition:: Solution
     :class: toggle
@@ -521,7 +524,7 @@ Do *not* use the IBasic or IDublinCore behavior to add title and description. In
                 required=False,
             )
 
-    Register the type in ``profiles/default/types.xml``
+    Register the type in :file:`profiles/default/types.xml`
 
     .. code-block:: xml
         :linenos:
@@ -536,7 +539,7 @@ Do *not* use the IBasic or IDublinCore behavior to add title and description. In
          <!-- -*- more types can be added here -*- -->
         </object>
 
-    The FTI goes in ``profiles/default/types/speaker.xml``. Again we use ``Item`` as the base-class:
+    The FTI goes in :file:`profiles/default/types/speaker.xml`. Again we use :py:class:`Item` as the base-class:
 
     .. code-block:: xml
         :linenos:

--- a/mastering_plone/eggs1.rst
+++ b/mastering_plone/eggs1.rst
@@ -16,22 +16,22 @@ Write Your Own Add-Ons to Customize Plone
 
 In this part you will:
 
-* Create a custom python distribution ``ploneconf.site`` to hold all the code
-* Modify buildout to install that distribution
+* Create a custom Python package :py:mod:`ploneconf.site` to hold all the code
+* Modify buildout to install that package
 
 
 Topics covered:
 
-* mr.bob and bobtemplates.plone
+* :py:mod:`mr.bob` and :py:mod:`bobtemplates.plone`
 * the structure of eggs
 
 
-Creating the distribution
+Creating the package
 -------------------------
 
-Our own code has to be organized as a python distribution, also called *egg*. An egg is a zip file or a directory that follows certain conventions. We are going to use `bobtemplates.plone <https://pypi.python.org/pypi/bobtemplates.plone>`_ to create a skeleton project. We only need to fill in the blanks.
+Our own code has to be organized as a Python package, also called *egg*. An egg is a zip file or a directory that follows certain conventions. We are going to use `bobtemplates.plone <https://pypi.python.org/pypi/bobtemplates.plone>`_ to create a skeleton project. We only need to fill in the blanks.
 
-We create and enter the ``src`` directory (*src* is short for *sources*) and call a script called ``mrbob`` from our buildout's bin directory:
+We create and enter the :file:`src` directory (*src* is short for *sources*) and call a script called :command:`mrbob` from our buildout's :file:`bin` directory:
 
 .. code-block:: bash
 
@@ -57,66 +57,73 @@ We have to answer some questions about the add-on. We will press :kbd:`Enter` (i
 
 .. only:: not presentation
 
-    If this is your first egg, this is a very special moment. We are going to create the egg with a script that generates a lot of necessary files. They all are necessary, but sometimes in a subtle way. It takes a while to understand their full meaning. Only last year I learned and understood why I should have a ``MANIFEST.in`` file. You can get along without one, but trust me, you get along better with a proper manifest file.
+    If this is your first egg, this is a very special moment.
+    We are going to create the egg with a script that generates a lot of necessary files.
+    They all are necessary, but sometimes in a subtle way.
+    It takes a while to understand their full meaning.
+    Only last year I learned and understood why I should have a :file:`MANIFEST.in` file.
+    You can get along without one, but trust me, you get along better with a proper manifest file.
 
 
 .. _eggs1-inspect-label:
 
-Inspecting the distribution
+Inspecting the package
 ---------------------------
 
-In ``src`` there is now a new folder ``ploneconf.site`` and in there is the new distribution. Let's have a look at some of the files:
+In :file:`src` there is now a new folder :file:`ploneconf.site` and in there is the new package. Let's have a look at some of the files:
 
-bootstrap-buildout.py, buildout.cfg, travis.cfg, .travis.yml, .coveragerc
-    You can ignore these files for now. They are here to create a buildout only for this egg to make testing it easier. Once we start writing tests for this distribution we will have another look at them.
+:file:`bootstrap-buildout.py`, :file:`buildout.cfg`, :file:`travis.cfg`, :file:`.travis.yml`, :file:`.coveragerc`
+    You can ignore these files for now. They are here to create a buildout only for this egg to make testing it easier. Once we start writing tests for this package we will have another look at them.
 
-README.rst, CHANGES.rst, CONTRIBUTORS.rst, docs/
+:file:`README.rst`, :file:`CHANGES.rst`, :file:`CONTRIBUTORS.rst`, :file:`docs/`
     The documentation, changelog, the list of contributors and the license of your egg goes in here.
 
-setup.py
-    This file configures the distribution, its name, dependencies and some metadata like the author's name and email address. The dependencies listed here are automatically downloaded when running buildout.
+:file:`setup.py`
+    This file configures the package, its name, dependencies and some metadata like the author's name and email address. The dependencies listed here are automatically downloaded when running buildout.
 
-src/ploneconf/site/
-    The distribution itself lives inside a special folder structure. That seems confusing but is necessary for good testability. Our distribution contains a `namespace package <https://www.python.org/dev/peps/pep-0420/>`_ called *ploneconf.site* and because of this there is a folder ``ploneconf`` with a ``__init__.py`` and in there another folder ``site`` and in there finally is our code.
-    From the buildout's perspective our code is in ``<your buildout directory>/src/ploneconf.site/src/ploneconf/site/<real code>``
+:file:`src/ploneconf/site/`
+    The package itself lives inside a special folder structure.
+    That seems confusing but is necessary for good testability.
+    Our package contains a `namespace package <https://www.python.org/dev/peps/pep-0420/>`_ called *ploneconf.site* and because of this there is a folder :file:`ploneconf` with a :file:`__init__.py` and in there another folder :file:`site` and in there finally is our code.
+    From the buildout's perspective our code is in :file:`{your buildout directory}/src/ploneconf.site/src/ploneconf/site/{real code}`
 
 
 .. note::
 
-    Unless discussing the buildout we will from now on silently omit these folders when describing files and assume that ``<your buildout directory>/src/ploneconf.site/src/ploneconf/site/`` is the root of our distribution!
+    Unless discussing the buildout we will from now on silently omit these folders when describing files and assume that :file:`{your buildout directory}/src/ploneconf.site/src/ploneconf/site/` is the root of our package!
 
 
-configure.zcml (src/ploneconf/site/configure.zcml)
-    The phone book of the distribution. By reading it you can find out which functionality is registered though the component architecture.
+:file:`configure.zcml` (:file:`src/ploneconf/site/configure.zcml`)
+    The phone book of the distribution. By reading it you can find out which functionality is registered using the component architecture.
 
-setuphandlers.py (src/ploneconf/site/setuphandlers.py)
+:file:`setuphandlers.py` (:file:`src/ploneconf/site/setuphandlers.py`)
     This holds code that is automatically run when installing and uninstalling our add-on.
 
-interfaces.py (src/ploneconf/site/interfaces.py)
+:file:`interfaces.py` (:file:`src/ploneconf/site/interfaces.py`)
     Here a browserlayer is defined in a straightforward python class. We will need it later.
 
-testing.py
+:file:`testing.py`
     This holds the setup for running tests.
 
-tests/
+:file:`tests/`
     This holds the tests.
 
-browser/
-    This directory is a python package (because it has a ``__init__.py``) and will by convention hold most things that are visible in the browser.
+:file:`browser/`
+    This directory is a python package (because it has a :file:`__init__.py`) and will by convention hold most things that are visible in the browser.
 
-browser/configure.zcml
+:file:`browser/configure.zcml`
     The phonebook of the browser package. Here views, resources and overrides are registered.
 
-browser/overrides/
+:file:`browser/overrides/`
     This add-on is already configured to allow overriding existing default Plone templates.
 
-browser/static/
+:file:`browser/static/`
     A directory that holds static resources (images/css/js). The files in here will be accessible through URLs like ``++resource++ploneconf.site/myawesome.css``
 
-profiles/default/
-    This folder contains the GenericSetup profile. During the training we will put some xml files here that hold configuration for the site.
+:file:`profiles/default/`
+    This folder contains the GenericSetup profile. During the training we will put some XML files here that hold configuration for the site.
 
-profiles/default/metadata.xml
+:file:`profiles/default/metadata.xml`
     Version number and dependencies that are auto-installed when installing our add-on.
 
 ..    profiles/uninstall/
@@ -125,10 +132,10 @@ profiles/default/metadata.xml
 
 .. _eggs1-include-label:
 
-Including the distribution in Plone
+Including the package in Plone
 -----------------------------------
 
-Before we can use our new distribution we have to tell Plone about it. Edit ``buildout.cfg`` and uncomment ``ploneconf.site`` in the sections `auto-checkout`, `eggs` and `test`:
+Before we can use our new package we have to tell Plone about it. Edit :file:`buildout.cfg` and uncomment ``ploneconf.site`` in the sections `auto-checkout`, `eggs` and `test`:
 
 .. code-block:: cfg
     :emphasize-lines: 4, 32, 40
@@ -174,7 +181,7 @@ Before we can use our new distribution we have to tell Plone about it. Edit ``bu
     test-eggs +=
         ploneconf.site [test]
 
-This tells Buildout to add the egg ``ploneconf.site``. The sources for this eggs are defined in the section `[sources]` at the bottom of `buildout.cfg`.
+This tells Buildout to add the egg :py:mod:`ploneconf.site`. The sources for this eggs are defined in the section ``[sources]`` at the bottom of :file:`buildout.cfg`.
 
 .. code-block:: cfg
    :emphasize-lines: 2
@@ -185,7 +192,7 @@ This tells Buildout to add the egg ``ploneconf.site``. The sources for this eggs
    starzel.votable_behavior = git https://github.com/collective
 
 
-The definition tells buildout not to download it from pypi, and expect it in ``src/ploneconf.site``. This is done with the directive *fs*, which allows you to add eggs on the filesystem without a version control system.
+The definition tells buildout not to download it from pypi, and expect it in :file:`src/ploneconf.site`. This is done with the directive *fs*, which allows you to add eggs on the filesystem without a version control system.
 
 Now run buildout to reconfigure Plone with the updated configuration:
 
@@ -193,6 +200,6 @@ Now run buildout to reconfigure Plone with the updated configuration:
 
     $ ./bin/buildout
 
-After restarting Plone with ``./bin/instance fg`` the new add-on `ploneconf.site` is available for install like PloneFormGen or Plone True Gallery.
+After restarting Plone with :command:`./bin/instance fg` the new add-on :py:mod:`ploneconf.site` is available for install like PloneFormGen or Plone True Gallery.
 
 We will not install it now since we did not add any of our own code or configuration yet. Let's do that next.

--- a/mastering_plone/eggs2.rst
+++ b/mastering_plone/eggs2.rst
@@ -3,7 +3,7 @@
 Creating Reusable Packages
 ==========================
 
-We already created the package ``ploneconf.site``  much earlier.
+We already created the package :py:mod:`ploneconf.site`  much earlier.
 
 In this part you will:
 
@@ -11,7 +11,7 @@ In this part you will:
 
 Topics covered:
 
-* mr.bob
+* :py:mod:`mr.bob`
 
 
 Now you are going to create a feature that is completely independent of the ploneconf site and can be reused in other packages.

--- a/mastering_plone/embed.rst
+++ b/mastering_plone/embed.rst
@@ -80,9 +80,10 @@ To add the behavior to talks, we do this in :file:`profiles/default/types/talk.x
 
 .. note::
 
-    After changing the ``metadata.xml`` you have to restart your site since unlike other GenericSetup XML files that file is cached.
+    After changing the :file:`metadata.xml` you have to restart your site since unlike other GenericSetup XML files that file is cached.
 
-    Managing dependencies in metadata.xml is good practice. We can't rely on remembering what we'd have to do by hand. In Plone 4 we should also have added ``<dependency>profile-plone.app.contenttypes:plone-content</dependency>`` like the `documentation for plone.app.contenttypes <http://docs.plone.org/external/plone.app.contenttypes/docs/README.html#installation-as-a-dependency-from-another-product>`_ recommends.
+    Managing dependencies in :file:`metadata.xml` is good practice. We can't rely on remembering what we'd have to do by hand.
+    In Plone 4 we should also have added :samp:`<dependency>profile-plone.app.contenttypes:plone-content</dependency>` like the `documentation for plone.app.contenttypes <http://docs.plone.org/external/plone.app.contenttypes/docs/README.html#installation-as-a-dependency-from-another-product>`_ recommends.
 
     Read more: http://docs.plone.org/develop/addons/components/genericsetup.html#dependencies
 
@@ -100,11 +101,14 @@ To add the behavior to talks, we do this in :file:`profiles/default/types/talk.x
 
     Now you can reinstall your Plone site.
 
-    Everybody can now vote on talks. That's not what we wanted. We only want reviewers to vote on pending Talks. This means the permission has to change depending on the workflow state. Luckily, workflows can be configured to do just that. Since Talks already have their own workflow we also won't interfere with other content.
+    Everybody can now vote on talks. That's not what we wanted. We only want reviewers to vote on *pending* Talks.
+    This means the permission has to change depending on the workflow state. Luckily, workflows can be configured to do just that.
+    Since Talks already have their own workflow we also won't interfere with other content.
 
     First, we have to tell the workflow that it will be managing more permissions. Next, for each state we have to configure which role has the two new permissions.
 
-    That is a very verbose configuration, maybe you want to do it in the web interface and export the settings. On the other hand, it is easy to make a simple mistake in both ways. I will just present the xml way here.
+    That is a very verbose configuration, maybe you want to do it in the web interface and export the settings.
+    Whichever way you choose, it is easy to make a simple mistake. I will just present the XML way here.
 
 The config for the Workflow is in :file:`profiles/default/workfows/talks_workflow.xml`
 

--- a/mastering_plone/events.rst
+++ b/mastering_plone/events.rst
@@ -23,7 +23,7 @@ In this chapter we will
 * enable this behavior for talks
 * display the date in the talkview
 
-First we enable the behavior ``IEventBasic`` for talks in ``profiles/default/types/talk.xml``
+First we enable the behavior :py:class:`IEventBasic` for talks in :py:mod:`profiles/default/types/talk.xml`
 
 .. code-block:: xml
     :linenos:
@@ -41,7 +41,7 @@ After we activate the behavior by hand or reinstalled the add-on we will now hav
 
 To display the new field we reuse a default event summary view as documented in http://ploneappevent.readthedocs.org/en/latest/development.html#reusing-the-event-summary-view-to-list-basic-event-information
 
-Edit ``browser/templates/talkview.pt``
+Edit :file:`browser/templates/talkview.pt`
 
 .. code-block:: html
     :linenos:
@@ -98,7 +98,7 @@ Find out where ``event_summary`` comes from and describe how you could override 
 ..  admonition:: Solution
     :class: toggle
 
-    Use your editor or grep to search all zcml-files in the folder ``packages`` for the string ``name="event_summary"``
+    Use your editor or grep to search all zcml-files in the folder :file:`packages` for the string ``name="event_summary"``
 
     ..  code-block:: bash
 
@@ -119,7 +119,7 @@ Find out where ``event_summary`` comes from and describe how you could override 
           layer="..interfaces.IBrowserLayer"
           />
 
-    So there is a class ``plone.app.event.browser.event_summary.EventSummaryView`` and a template ``event_summary.pt`` that could be overridden with ``z3c.jbot`` by copying it as ``plone.app.event.browser.event_summary.pt`` in ``browser/overrides``.
+    So there is a class :py:class:`plone.app.event.browser.event_summary.EventSummaryView` and a template :file:`event_summary.pt` that could be overridden with :py:mod:`z3c.jbot` by copying it as :file:`plone.app.event.browser.event_summary.pt` in :file:`browser/overrides`.
 
 
 Exercise 2
@@ -130,7 +130,7 @@ Find out where the event behavior is defined and which fields it offers.
 ..  admonition:: Solution
     :class: toggle
 
-    The id with which the behavior is registered in ``Talk.xml`` is a python path. So ``plone.app.event.dx.behaviors.IEventBasic`` can be found in ``packages/plone.app.event/plone/app/event/dx/behaviors.py``
+    The id with which the behavior is registered in :file:`Talk.xml` is a Python path. So :py:class:`plone.app.event.dx.behaviors.IEventBasic` can be found in :file:`packages/plone.app.event/plone/app/event/dx/behaviors.py`
 
     ..  code-block:: python
 

--- a/mastering_plone/export_code.rst
+++ b/mastering_plone/export_code.rst
@@ -15,7 +15,7 @@ Return to Dexterity: Moving contenttypes into Code
 
 In this part you will:
 
-* Move the type *talk* into ``ploneconf.site``
+* Move the *Talk* type into :py:mod:`ploneconf.site`
 * Improve the schema and the FTI
 
 
@@ -33,13 +33,13 @@ Steps:
 * Return to the Dexterity control panel
 * Export the *Talk* Type Profile and save the file
 * Delete the *Talk* from the site before installing it from the file system
-* Extract the files from the exported tar file and add them to our add-on package in ``profiles/default/``
+* Extract the files from the exported tar file and add them to our add-on package in :file:`profiles/default/`
 
 .. note::
 
-    From the buildout directory perspective that is ``src/ploneconf.site/src/ploneconf/site/profiles/default/``
+    From the buildout directory perspective that is :file:`src/ploneconf.site/src/ploneconf/site/profiles/default/`
 
-The file ``profiles/default/types.xml`` tells Plone that there is a new content type defined in file ``talk.xml``.
+The file :file:`profiles/default/types.xml` tells Plone that there is a new content type defined in file :file:`talk.xml`.
 
 .. code-block:: xml
 
@@ -50,7 +50,7 @@ The file ``profiles/default/types.xml`` tells Plone that there is a new content 
      <!-- -*- more types can be added here -*- -->
     </object>
 
-Upon installing, Plone reads the file ``profiles/default/types/talk.xml`` and registers a new type in ``portal_types`` (you can find and inspect this tool in the ZMI!) with the information taken from that file.
+Upon installing, Plone reads the file :file:`profiles/default/types/talk.xml` and registers a new type in ``portal_types`` (you can find and inspect this tool in the ZMI!) with the information taken from that file.
 
 ..  code-block:: xml
 
@@ -157,7 +157,7 @@ Now our package has some real contents. So, we'll need to reinstall it (if insta
 
 The escaped inline xml is simply too ugly to look at. You should move it to a separate file!
 
-Create a new folder ``content`` in the main directory (from the buildout directory perspective that is ``src/ploneconf.site/src/ploneconf/site/content/``). Inside add an empty file ``__init__py`` and a file ``talk.xml`` that contains the real xml (copied from http://localhost:8080/Plone/dexterity-types/talk/@@modeleditor and beautified with some online xml formatter (http://lmgtfy.com/?q=xml+formatter))
+Create a new folder :file:`content` in the main directory (from the buildout directory perspective that is :file:`src/ploneconf.site/src/ploneconf/site/content/`). Inside add an empty file :file:`__init__py` and a file :file:`talk.xml` that contains the real XML (copied from http://localhost:8080/Plone/dexterity-types/talk/@@modeleditor and beautified with some online XML formatter (http://lmgtfy.com/?q=xml+formatter))
 
 ..  code-block:: xml
     :linenos:
@@ -212,22 +212,22 @@ Create a new folder ``content`` in the main directory (from the buildout directo
         </schema>
       </model>
 
-Now remove the ugly model_source and instead point to the new xml file in the FTI by using the property ``model_file``:
+Now remove the ugly model_source and instead point to the new XML file in the FTI by using the property ``model_file``:
 
 ..  code-block:: xml
 
     <property name="model_source"></property>
     <property name="model_file">ploneconf.site.content:talk.xml</property>
 
-``ploneconf.site.content:talk.xml`` points to a file ``talk.xml`` to be found in the python path ``ploneconf.site.content``. The ``__ìnit__.py`` is needed to turn the folder ``content`` into a python-module. It is best-practice to add schemas in this folder and in later chapters you will add new types with pythons-schemata in the same folder.
+``ploneconf.site.content:talk.xml`` points to a file :file:`talk.xml` to be found in the Python path ``ploneconf.site.content``. The :file:`__ìnit__.py` is needed to turn the folder :file:`content` into a Python package. It is best-practice to add schemas in this folder, and in later chapters you will add new types with pythons-schemata in the same folder.
 
 ..  note::
 
     The default types of Plone 5 also have an xml schema like this since that allows the fields of the types to be editable trough the web! Fields for types with a python schema are not editable ttw.
 
-`Dexterity XML <http://docs.plone.org/external/plone.app.dexterity/docs/reference/dexterity-xml.html>`_ is very powerful. By editing it (not all features have a UI) you should be able to do everything you can do with a python schema.
+`Dexterity XML <http://docs.plone.org/external/plone.app.dexterity/docs/reference/dexterity-xml.html>`_ is very powerful. By editing it (not all features have a UI) you should be able to do everything you can do with a Python schema.
 
-Our talks use a dropdown for ``type_of_talk`` and a multiselect for ``audience``. Radio-buttons and checkboxes would be the better choice here. Modify the xml to make that change happen:
+Our talks use a dropdown for :guilabel:`type_of_talk` and a multiselect for :guilabel:`audience`. Radio-buttons and checkboxes would be the better choice here. Modify the XML to make that change happen:
 
 ..  code-block:: xml
     :linenos:
@@ -289,7 +289,7 @@ Our talks use a dropdown for ``type_of_talk`` and a multiselect for ``audience``
 Exercise 1
 ++++++++++
 
-Create a new package called ``collective.behavior.myfeature``. Inspect the directory structure of this package. Delete it after you are done.
+Create a new package called :py:mod:`collective.behavior.myfeature`. Inspect the directory structure of this package. Delete it after you are done.
 
 ..  admonition:: Solution
     :class: toggle
@@ -299,13 +299,13 @@ Create a new package called ``collective.behavior.myfeature``. Inspect the direc
         $ cd src
         $ ../bin/mrbob -O collective.behavior.myfeature bobtemplates:plone_addon
 
-    Many packages that are part of Plone and some add-ons use a nested namespace such as ``plone.app.contenttypes``.
+    Many packages that are part of Plone and some add-ons use a nested namespace such as :py:mod:`plone.app.contenttypes`.
 
 
 Exercise 2
 ++++++++++
 
-Go to the ZMI and and in ``portal_types`` look for the definition of the new ``Talk`` content type. Now deactivate *Implicitly addable?* and save. Go back to the site can you identify what this change has caused? And why is that useful?
+Go to the ZMI and look for the definition of the new ``Talk`` content type in ``portal_types``. Now deactivate :guilabel:`Implicitly addable?` and save. Go back to the site. Can you identify what this change has caused? And why is that useful?
 
 ..  admonition:: Solution
     :class: toggle
@@ -316,7 +316,7 @@ Go to the ZMI and and in ``portal_types`` look for the definition of the new ``T
 
     With this method you can prevent content that only makes sense inside some defined structure to show up in places where they do not belong.
 
-    The equivalent setting for disabling *Implicitly addable* in ``Talk.xml`` is:
+    The equivalent setting for disabling :guilabel:`Implicitly addable` in :file:`Talk.xml` is:
 
     .. code-block:: xml
 

--- a/mastering_plone/extending.rst
+++ b/mastering_plone/extending.rst
@@ -59,7 +59,7 @@ Skin Folders
 
     By default, your site has a ``custom`` folder, and items are first searched for in that folder.
 
-    To customize the logo, you copy it into the ``custom`` folder, and change it there. This way you can change templates, CSS styles, images and behavior, because a container may contain python scripts.
+    To customize the logo, you copy it into the ``custom`` folder, and change it there. This way you can change templates, CSS styles, images and behavior, because a container may contain Python scripts.
 
     Skin-folder style customization may be accomplished TTW via the ZMI, or with add-on packages. Many older-style packages create their own skin folder and add it to the skin layer for Plone when installed.
 

--- a/mastering_plone/features.rst
+++ b/mastering_plone/features.rst
@@ -95,7 +95,7 @@ Open the `bin/instance` script in your favorite editor. Now let's say you want P
     The second to last line points to the configuration file your Plone instance is using. An absolute path is used so it might differ depending on the installation method. Open the `zope.conf` file in your
     editor and look for the section:
 
-    .. code-block::
+    .. code-block:: xml
 
         <http-server>
          address 8080

--- a/mastering_plone/features.rst
+++ b/mastering_plone/features.rst
@@ -54,6 +54,10 @@ Some commands you will use rather often are::
     This opens a form to create a Plone site.
     Use :samp:`Plone` as the site id.
 
+    You now have the option to select some add-ons before you create the site.
+    Since we will use Dexterity from the beginning we select :guilabel:`Dexterity-based Plone Default Types`.
+    This way even the initial content on our page will be built with dexterity by the add-on :py:mod:`plone.app.contenttypes` which will be the default in Plone 5.
+
     You will be automatically redirected to the new site.
 
 .. only:: presentation
@@ -178,8 +182,8 @@ On the edit bar, we find options affecting the current context...
 * :guilabel:`user actions`
 
 Some edit bar options only show when appropriate;
-for example, ``folder contents`` and ``add`` are only shown for Folders.
-``rules`` is currently invisible because we have no content rules available.
+for example, :guilabel:`folder contents` and :guilabel:`add` are only shown for Folders.
+:guilabel:`rules` is currently invisible because we have no content rules available.
 
 
 
@@ -378,7 +382,7 @@ Manage members and groups
 Workflows
 ---------
 
-Take a look at the ``state`` drop-down on the edit bar on the homepage.
+Take a look at the :guilabel:`state` drop-down on the edit bar on the homepage.
 Now, navigate to one of the folders just added.
 The homepage has the status ``published`` and the new content is ``private``.
 
@@ -448,7 +452,7 @@ Typically, you use it to set a special workflow in a folder that will govern eve
 Since it has effect in a "place" in a site, this mechanism is often called "Placeful Workflow".
 
 As with working-copy support, Placeful Workflow ships with Plone but needs to be activated via the add-on configuration page.
-Once it's added, a ``Policy`` option will appear on the state menu to allow setting a placeful workflow policy.
+Once it's added, a :guilabel:`Policy` option will appear on the state menu to allow setting a placeful workflow policy.
 
 .. Note::
 

--- a/mastering_plone/frontpage.rst
+++ b/mastering_plone/frontpage.rst
@@ -232,7 +232,7 @@ Calling the macro in python looks like this  ``metal:use-macro="python:context.r
 
 .. note::
 
-    In ``talklistview.pt`` the call ``view/talks"`` calls the method ``talks`` from the browser view ``TalkListView`` to get the talks. Reused as a macro on the frontpage it now uses the method ``talks`` by the ``frontpageView`` to get a different list!
+    In :file:`talklistview.pt` the call :samp:`view/talks"` calls the method :py:meth:`talks` from the browser view :py:class:`TalkListView` to get the talks. Reused as a macro on the frontpage it now uses the method :py:meth:`talks` by the ``frontpageView`` to get a different list!
 
     Also: It is not always smart to do that since maybe you want to display other data.
 

--- a/mastering_plone/grok.rst
+++ b/mastering_plone/grok.rst
@@ -19,7 +19,7 @@ So, we will write our browser view as a grok view. From the component architectu
 
 Grok is not part of plone. We have to add it as a dependency to our egg.
 
-Open setup.py, and add ``five.grok`` to the list off add-ons in ``install_requires``::
+Open :file:`setup.py`, and add :py:mod:`five.grok` to the list of add-ons in ``install_requires``::
 
     ...
         zip_safe=False,
@@ -30,7 +30,7 @@ Open setup.py, and add ``five.grok`` to the list off add-ons in ``install_requir
 
 You need to run buildout now.
 
-Grok nearly magically does find all its annotations. Since its not complete magic, you have to tell grok where to look for grok code. This requires a single line of zcml, that line ensures that your complete package is `grokked`.
+Grok nearly magically does find all its annotations. Since its not complete magic, you have to tell grok where to look for grok code. This requires a single line of ZCML. This line ensures that your complete package is `grokked`.
 
 .. code-block:: xml
     :linenos:
@@ -50,9 +50,9 @@ Grok nearly magically does find all its annotations. Since its not complete magi
         <grok:grok package="." />
         ....
 
-This new grok statement takes care of finding everything grok related.
+This new grok statement takes care of finding everything grok-related.
 
-Now we can add a grok view in a new file ``views.py``:
+Now we can add a grok view in a new file :file:`views.py`:
 
 .. code-block:: python
     :linenos:
@@ -66,9 +66,9 @@ Now we can add a grok view in a new file ``views.py``:
         grok.require("zope2.View")
         grok.context(Interface)
 
-By convention the template must be in a subdirectory called ``views_templates`` and it must be named `talkview.pt`
+By convention the template must be in a subdirectory called :file:`views_templates` and it must be named :file:`talkview.pt`
 
-If we used ``grok`` for viewlets we would not need to register them in the ``configure.zcml`` but do that in python. We would add a file viewlets.py containing the viewlet-class.
+If we used ``grok`` for viewlets we would not need to register them in the :file:`configure.zcml` but do that in python. We would add a file :file:`viewlets.py` containing the viewlet-class.
 
 .. code-block:: python
     :linenos:
@@ -80,4 +80,4 @@ If we used ``grok`` for viewlets we would not need to register them in the ``con
     class SocialViewlet(grok.Viewlet):
         grok.viewletmanager(viewletIFs.IBelowContentTitle)
 
-This would do the same as the code above using grok's paradigm of convention over configuration. In browser views the reference is called view, note that in grok viewlets it is called viewlets (in that case ``viewlet/lanyrd_link``).
+This would do the same as the code above using grok's paradigm of convention over configuration. In browser views the reference is called view; note that in grok viewlets it is called viewlets (in that case ``viewlet/lanyrd_link``).

--- a/mastering_plone/plone5.rst
+++ b/mastering_plone/plone5.rst
@@ -13,7 +13,7 @@ Default Theme
 
 The new default theme is called `Barceloneta <https://github.com/plone/plonetheme.barceloneta/>`_
 
-It is a Diazo theme, meaning it uses plone.app.theming to insert the output of Plone into static html/css.
+It is a Diazo theme, meaning it uses :py:mod:`plone.app.theming` to insert the output of Plone into static html/css.
 
 It uses html5, so it uses ``<header>``, ``<nav>``, ``<aside>``, ``<section>``, ``<article>`` and ``<footer>`` for semantic html.
 
@@ -21,7 +21,7 @@ The theme is mostly built with `LESS <http://lesscss.org/>`_ (lots of it!) and u
 
 The `index.html <https://github.com/plone/plonetheme.barceloneta/blob/master/plonetheme/barceloneta/theme/index.html>`_ and `rules.xml <https://github.com/plone/plonetheme.barceloneta/blob/master/plonetheme/barceloneta/theme/rules.xml>`_ are actually not that complicated. Have a look at them.
 
-The following example from the ``rules.xml`` makes sure that the banner saying *"Welcome! Plone 5 rocks!"* is only visible on the frontpage:
+The following example from :file:`rules.xml` makes sure that the banner saying *"Welcome! Plone 5 rocks!"* is only visible on the frontpage:
 
 .. code-block:: xml
 
@@ -31,7 +31,7 @@ The following example from the ``rules.xml`` makes sure that the banner saying *
           href="/@@hero"
           css:if-content="body.template-document_view.section-front-page" />
 
-The browser-view ``@@hero`` (you can find it by searching all zcml-files for ``name="hero"``) is only included when the body-tag of the current page has the css-classes ``template-document_view`` and ``section-front-page``.
+The browser-view ``@@hero`` (you can find it by searching all ZCML-files for ``name="hero"``) is only included when the body-tag of the current page has the css-classes ``template-document_view`` and ``section-front-page``.
 
 
 .. _plone5-ui-widgets-label:
@@ -108,9 +108,9 @@ You can now put a full-grown ``pdb`` in a template.
 
     <?python import pdb; pdb.set_trace() ?>
 
-For debugging check out the variable ``econtext``, it holds all the current elements.
+For debugging check out the variable :py:obj:`econtext`, it holds all the current elements.
 
-You can also add real python blocks inside templates.
+You can also add real Python blocks inside templates.
 
 .. code-block:: html
 
@@ -180,7 +180,7 @@ New portlet manager
 
 ``plone.footerportlets`` is a new place to put portlets. The footer (holding the footer, site_actions, colophon) is now built from portlets. This means you can edit the footer TTW.
 
-There is also a useful new portlet type ``Actions`` used for displaying the site_actions.
+There is also a useful new portlet type :guilabel:`Actions` used for displaying the site_actions.
 
 
 .. _plone5-skins-label:

--- a/mastering_plone/registry.rst
+++ b/mastering_plone/registry.rst
@@ -49,14 +49,14 @@ Let's store two values in the registry:
 
 You cannot create values ttw, instead they need to be registered using Generic Setup.
 
-Open the file ``profiles/default/registry.xml``. You already registered several new settings in there:
+Open the file :file:`profiles/default/registry.xml`. You already registered several new settings in there:
 
 - You enabled self registration
 - You stored a site-logo
 - You registered additional criteria useable for Collections
 
 
-Adding the following code to ``registry.xml`` creates a new value in the registry upon installation of the package.
+Adding the following code to :file:`registry.xml`. This creates a new value in the registry upon installation of the package.
 
 ..  code-block:: xml
 
@@ -69,7 +69,7 @@ Adding the following code to ``registry.xml`` creates a new value in the registr
         <value>False</value>
     </record>
 
-When creating a new site a lot of settings are created in the same way. See https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/profiles/dependencies/registry.xml to see how ``Products.CMFPlone`` registers values.
+When creating a new site a lot of settings are created in the same way. See https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/profiles/dependencies/registry.xml to see how :py:mod:`Products.CMFPlone` registers values.
 
 ..  code-block:: xml
 
@@ -96,7 +96,7 @@ In python you can access the registry like this:
     registry = getUtility(IRegistry)
     start = registry.get('ploneconf.date_of_conference')
 
-``plone.api`` holds methods to make this even easier:
+:py:mod:`plone.api` holds methods to make this even easier:
 
 ..  code-block:: python
 
@@ -121,7 +121,7 @@ For this you define a interface for the schema and a view that auto-generates a 
         class=".controlpanel.PloneconfControlPanelView"
     />
 
-Add a file ``controlpanel.py``:
+Add a file :file:`controlpanel.py`:
 
 ..  code-block:: python
 
@@ -160,7 +160,7 @@ Add a file ``controlpanel.py``:
         PloneconfControlPanelForm, ControlPanelFormWrapper)
 
 
-With this way of using fields you don't have to register the values in ``registry.xml``, instead you have to register the interface:
+With this way of using fields you don't have to register the values in :file:`registry.xml`, instead you have to register the interface:
 
 ..  code-block:: xml
 

--- a/mastering_plone/relations.rst
+++ b/mastering_plone/relations.rst
@@ -3,7 +3,7 @@ Relations
 
 You can model relationships between content items by placing them in a hierarchy (a folder *speakers* containing the (folderish) speakers and within each speaker the talks) or by linking them to each other in Richtext-Fields. But where would you store a talk that two speakers give together together?
 
-Relations allow developers to model relationships between objects without a links or a hierarchy. The behavior ``plone.app.relationfield.behavior.IRelatedItems`` provides the field *Related Items* in the tab *Categorization*. That field simply says ``a`` is somehow related to ``b``.
+Relations allow developers to model relationships between objects without a links or a hierarchy. The behavior :py:class:`plone.app.relationfield.behavior.IRelatedItems` provides the field :guilabel:`Related Items` in the tab :guilabel:`Categorization`. That field simply says ``a`` is somehow related to ``b``.
 
 By using custom relations you can model your data in a much more meaningful way.
 
@@ -101,15 +101,15 @@ So we add a method to the view to return the related items so that we're able to
             results.append(brains[0])
         return results
 
-We use ``rel.to_path`` and use the items path to query the catalog for its catalog-entry. This is much more efficient than using ``rel.to_object`` since we don't have to wake up any objects. Setting ``depth`` to ``0`` will only return items with exactly this path, so it will always return a list with one item.
+We use :py:meth:`rel.to_path` and use the items path to query the catalog for its catalog-entry. This is much more efficient than using :py:meth:`rel.to_object` since we don't have to wake up any objects. Setting ``depth`` to ``0`` will only return items with exactly this path, so it will always return a list with one item.
 
 ..  note::
 
-    Using the path sounds a little complicated and it would indeed be more convenient if a ``RelationItem`` would contain the ``UID`` (so we can query the catalog for that) or if the ``portal_catalog`` would index the ``IntId``. But that's the way it is for now.
+    Using the path sounds a little complicated and it would indeed be more convenient if a :py:class:`RelationItem` would contain the ``UID`` (so we can query the catalog for that) or if the ``portal_catalog`` would index the ``IntId``. But that's the way it is for now.
 
-For reference look at how the default viewlet displays the information for related items stored by the behavior ``IRelatedItems``. See how it does exatly the same in ``related2brains``.
-This is the python-path for the viewlet: ``plone.app.layout.viewlets.content.ContentRelatedItems``
-This is the file-path for the template: ``plone/app/layout/viewlets/document_relateditems.pt``
+For reference look at how the default viewlet displays the information for related items stored by the behavior :py:class:`IRelatedItems`. See how it does exactly the same in ``related2brains``.
+This is the Python-path for the viewlet: :py:class:`plone.app.layout.viewlets.content.ContentRelatedItems`
+This is the file-path for the template: :file:`plone/app/layout/viewlets/document_relateditems.pt`
 
 
 Creating Relationfields through the web

--- a/mastering_plone/resources.rst
+++ b/mastering_plone/resources.rst
@@ -27,9 +27,9 @@ We want to change that a little to allow the resources to be editable and overri
         directory="static"
         />
 
-Now all files we put in the `static` folder can be found via the url http://localhost:8080/Plone/++plone++ploneconf.site/the_real_filename.css
+Now all files we put in the :file:`static` folder can be found via the url http://localhost:8080/Plone/++plone++ploneconf.site/the_real_filename.css
 
-Let's create a file ``ploneconf.css`` in the `static` folder with some css:
+Let's create a file :file:`ploneconf.css` in the :file:`static` folder with some CSS:
 
 .. code-block:: css
     :linenos:
@@ -71,14 +71,16 @@ Let's create a file ``ploneconf.css`` in the `static` folder with some css:
 
 If we now access http://localhost:8080/Plone/++plone++ploneconf.site/ploneconf.css we see our css-file.
 
-Also add a ``ploneconf.js`` in the same folder but leave it empty for now. You could add some javascript to that file later.
+Also add a :file:`ploneconf.js` in the same folder but leave it empty for now. You could add some JavaScript to that file later.
 
-How do our javascript and css files get used when visiting the page? So far the new files are accessible in the browser but we want Plone to use them everytime we access the page. Adding them directly into the html is not a good solution, having many css and js files slows down the page loading.
+How do our JavaScript and CSS files get used when visiting the page?
+So far the new files are accessible in the browser but we want Plone to use them every time we access the page.
+Adding them directly into the HTML is not a good solution, having many CSS and JS files slows down the page loading.
 
 For this we need to register a *bundle* that contains these files. Plone will then make sure that all files that are part of this bundle are also deployed.
 We need to register our resources with GenericSetup.
 
-Open the file ``profiles/default/registry.xml`` and add the following:
+Open the file :file:`profiles/default/registry.xml` and add the following:
 
 .. code-block:: xml
     :linenos:

--- a/mastering_plone/restapi.rst
+++ b/mastering_plone/restapi.rst
@@ -3,7 +3,7 @@ Using plone.restapi
 
 In this chapter, we will have a look at the relatively new addon `plone.restapi <https://plonerestapi.readthedocs.io/en/latest/index.html>`_. It provides a hypermedia API to access Plone content using REST (Representational State Transfer).
 
-We will use `plone.restapi` to develop a small standalone 'single page app' targeted at mobile devices. We will present our users with a simple list of conference talks. We add lightning talks as a new type of talk. Users will be able to submit lightning talks e.g. using their mobile phone.
+We will use :py:mod:`plone.restapi` to develop a small standalone 'single page app' targeted at mobile devices. We will present our users with a simple list of conference talks. We add lightning talks as a new type of talk. Users will be able to submit lightning talks e.g. using their mobile phone.
 
 We have the following tasks:
 
@@ -14,12 +14,15 @@ We have the following tasks:
 Installing plone.restapi
 ------------------------
 
-We install `plone.restapi` like any other add-on package by adding it to `buildout.cfg` and then activating it in the `Add-ons` panel. This will automatically add and configure a new PAS plugin named `jwt_auth` used for JSON web token authentication.
+We install :py:mod:`plone.restapi` like any other add-on package by adding it to :file:`buildout.cfg` and then activating it in the :guilabel:`Add-ons` panel.
+This will automatically add and configure a new PAS plugin named `jwt_auth` used for JSON web token authentication.
 
 Explore the API
 ---------------
 
-Make sure you add some talks to the talks folder and then start exploring the API. We recommend using `Postman <http://www.getpostman.com>`_ or a similar tool, but you can also use `requests <https://pypi.python.org/pypi/requests>`_ in a Python virtual env. `plone.restapi` uses 'content negotiation' to determine wether a client wants a REST API response - if you set the `Accept` HTTP header to `application/json` Plone will provide responses in JSON format. Some requests you could try:
+Make sure you add some talks to the talks folder and then start exploring the API.
+We recommend using `Postman <http://www.getpostman.com>`_ or a similar tool, but you can also use `requests <https://pypi.python.org/pypi/requests>`_ in a Python virtual env.
+:py:mod:`plone.restapi` uses 'content negotiation' to determine whether a client wants a REST API response - if you set the ``Accept`` HTTP header to ``application/json``, Plone will provide responses in JSON format. Some requests you could try:
 
 .. code::
 
@@ -40,12 +43,12 @@ Make sure you add some talks to the talks folder and then start exploring the AP
 Exercise
 ++++++++
 
-REST APIs use HTTP verbs for manipulating content. `PATCH` is used to update an existing resource. Add a new talk in Plone and then update it's title to match 'Foo 42' using the REST API (from Postman or requests).
+REST APIs use HTTP verbs for manipulating content. ``PATCH`` is used to update an existing resource. Add a new talk in Plone and then update it's title to match 'Foo 42' using the REST API (from Postman or requests).
 
 ..  admonition:: Solution
     :class: toggle
 
-    We need to login to change content. Using JWT, we do so by POSTing credentials to the `@login` resource to obtain a JSON web token that we can subsequently use to authorize requests.
+    We need to login to change content. Using JWT, we do so by POSTing credentials to the ``@login`` resource to obtain a JSON web token that we can subsequently use to authorize requests.
 
     .. code-block:: http-request
 
@@ -66,7 +69,7 @@ REST APIs use HTTP verbs for manipulating content. `PATCH` is used to update an 
            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6bnVsbCwic3ViIjoiYWRtaW4iLCJleHAiOjE0NzQ5MTU4Mzh9.s27se99V7leTVTo26N_pbYskebR28W5NS87Fb7zowNk"
        }
 
-    Using the `requests` library from Python, you would do:
+    Using the :py:mod:`requests` library from Python, you would do:
 
     .. code-block:: python
 
@@ -94,7 +97,7 @@ REST APIs use HTTP verbs for manipulating content. `PATCH` is used to update an 
            "title": "Foo 42"
        }
 
-    Using `requests` again:
+    Using :py:mod:`requests` again:
 
     .. code-block:: python
 
@@ -107,9 +110,13 @@ REST APIs use HTTP verbs for manipulating content. `PATCH` is used to update an 
 Implementing the talklist
 -------------------------
 
-We will use `Mobile Angular UI <http://mobileangularui.com/>`_ to develop our app. This is a relatively lightweight javascript framework for developing hybrid web apps built on top of `AngularJS <https://angularjs.org/>`_. There are a lot of other frameworks available (e.g. Ionic, OnsenUI, Sencha, ...), but most of them have more dependencies than `Mobile Angular UI`. For example, most of them require NodeJS as a development web server. Our focus is Plone and interacting with `plone.restapi`, and `Mobile Angular UI` perfectly suits our needs because it simply let's us use Plone as our development webserver.
+We will use `Mobile Angular UI <http://mobileangularui.com/>`_ to develop our app.
+This is a relatively lightweight JavaScript framework for developing hybrid web apps built on top of `AngularJS <https://angularjs.org/>`_.
+There are a lot of other frameworks available (e.g. Ionic, OnsenUI, Sencha, ...), but most of them have more dependencies than `Mobile Angular UI`.
+For example, most of them require NodeJS as a development web server.
+Our focus is Plone and interacting with :py:mod:`plone.restapi`, and `Mobile Angular UI` perfectly suits our needs because it simply lets us use Plone as our development webserver.
 
-To get started, we download the current `master branch of Mobile Angular UI <https://github.com/mcasimir/mobile-angular-ui/archive/master.zip>`_ from Github, extract it and copy the `dist` folder into a new subdirectory of `browser` named `talklist`.
+To get started, we download the current `master branch of Mobile Angular UI <https://github.com/mcasimir/mobile-angular-ui/archive/master.zip>`_ from Github, extract it and copy the :file:`dist` folder into a new subdirectory of :file:`browser` named :file:`talklist`.
 So, assuming the current working directory is the buildout directory:
 
 .. code-block:: bash
@@ -119,7 +126,7 @@ So, assuming the current working directory is the buildout directory:
     $ mkdir src/ploneconf.site/src/ploneconf/site/browser/talklist
     $ cp -a mobile-angular-ui-master/dist src/ploneconf.site/src/ploneconf/site/browser/talklist/
 
-Then we add a new resource directory to `browser/configure.zcml`:
+Then we add a new resource directory to :file:`browser/configure.zcml`:
 
 .. code-block:: xml
 
@@ -128,7 +135,7 @@ Then we add a new resource directory to `browser/configure.zcml`:
         directory="talklist"
         />
 
-In the `browser/talklist` directory, we add an HTML page called `index.html`:
+In the :file:`browser/talklist` directory, we add an HTML page called :file:`index.html`:
 
 .. code-block:: html
 
@@ -183,7 +190,7 @@ In the `browser/talklist` directory, we add an HTML page called `index.html`:
       </body>
     </html>
 
-So far, the page will simply display a list of published talks. But we also need some javascript that we put into a file named `talklist.js` in the same folder:
+So far, the page will simply display a list of published talks. But we also need some JavaScript that we put into a file named :file:`talklist.js` in the same folder:
 
 .. code-block:: javascript
 
@@ -248,7 +255,10 @@ So far, the page will simply display a list of published talks. But we also need
 Submit lightning talks
 ----------------------
 
-We add a new type of talk: lightning talk. A lightning talk is a short presentation of up to 5 minutes duration that can cover just about any topic. The information we need to provide for lightning talks is far less than for the more formal types of talk. Often the information provided for lightning talks is restricted to the talk subject or title and the speaker name, but we allow for a short summary. Before they can submit a lightning talk, potential speakers will need to login and we will use their previously registered login name as the speaker's name to display in the talk list.
+We add a new type of talk: lightning talk. A lightning talk is a short presentation of up to 5 minutes duration that can cover just about any topic.
+The information we need to provide for lightning talks is far less than for the more formal types of talk.
+Often the information provided for lightning talks is restricted to the talk subject or title and the speaker name, but we allow for a short summary.
+Before they can submit a lightning talk, potential speakers will need to login and we will use their previously registered login name as the speaker's name to display in the talk list.
 
 Before we can start to submit lightning talks using REST calls from our single page app, we have to adapt the talk schema:
 
@@ -312,7 +322,8 @@ Before we can start to submit lightning talks using REST calls from our single p
       </schema>
     </model>
 
-Next, in our javascript code, we provide a method for logging in a user and another one to check wether the user has a valid JSON web token. We use the the `localStorage` facility of the browser to store the token on the client.
+Next, in our JavaScript code, we provide a method for logging in a user and another one to check whether the user has a valid JSON web token.
+We use the ``localStorage`` facility of the browser to store the token on the client.
 
 .. code-block:: javascript
 
@@ -340,7 +351,7 @@ Next, in our javascript code, we provide a method for logging in a user and anot
       };
     ...
 
-We continue with changes to `index.html` so that it uses the new methods. We provide a login form if the user doesn't have a valid JSON web token. Only authenticated users can see the rest of the page.
+We continue with changes to :file:`index.html` so that it uses the new methods. We provide a login form if the user doesn't have a valid JSON web token. Only authenticated users can see the rest of the page.
 
 .. code-block:: html
    :emphasize-lines: 5-31
@@ -422,7 +433,7 @@ Last we have to add some code that allows authenticated users to submit a lightn
 Exercise
 ---------
 
-Rewrite the `load_talks()` javascript method so that it uses the portal search instead of `/Plone/talks`. Sort the list by date.
+Rewrite the ``load_talks()`` javascript method so that it uses the portal search instead of ``/Plone/talks``. Sort the list by date.
 
 ..  admonition:: Solution
     :class: toggle

--- a/mastering_plone/sneak.rst
+++ b/mastering_plone/sneak.rst
@@ -40,7 +40,7 @@ Telling Plone about ploneconf.site
 ----------------------------------
 
 If you did not yet do this (it is covered in chapter :ref:`eggs1-label`) you will have to
-modify ``buildout.cfg`` to have Plone expect the egg ``ploneconf.site`` to be in ``src``.
+modify :file:`buildout.cfg` to have Plone expect the egg :py:mod:`ploneconf.site` to be in :file:`src`.
 
 .. code-block:: cfg
     :linenos:

--- a/mastering_plone/testing.rst
+++ b/mastering_plone/testing.rst
@@ -122,7 +122,7 @@ Plone tests
 
     Usually, you create three layers on your own, an integration layer, a functional layer and an acceptance test layer. If you were to test code that uses the Solr search engine, you'd use another layer that starts and stops solr between tests. But most of the time you just use the default layers you copied from somewhere or that mr.bob gave you.
 
-    By convention, layers are defined in a module ``testing`` in your module root, ie ``my.code.testing``. Your test classes should be in a folder named ``tests``
+    By convention, layers are defined in a module :py:mod:`testing` in your module root, ie :py:mod:`my.code.testing`. Your test classes should be in a folder named :file:`tests`
 
 Getting started
 ~~~~~~~~~~~~~~~
@@ -136,10 +136,10 @@ The person that wants to make your package work 5 years from now, knows now that
 
 This is why it makes sense to write these tedious tests.
 
-If nothing else matches, ``test_setup.py`` is the right location for anything GenericSetup related.
+If nothing else matches, :file:`test_setup.py` is the right location for anything GenericSetup related.
 In :ref:`eggs1-label` we created a content type. It is time to test this.
 
-We are going to create a test module named ``test_talk``:
+We are going to create a test module named :py:mod:`test_talk`:
 
 .. literalinclude::  ../ploneconf.site_sneak/chapters/02_export_code_p5/src/ploneconf/site/tests/test_talk.py
     :linenos:
@@ -167,7 +167,8 @@ Then we can create content. Looking through the code, we do not want the talks l
 Some advanced thing. Should you ever use an improved search system like collective.solr, results might get batched automatically. Check that if you have 101 talks, that you also get back 101 talks.
 Think about what you want to check in your results. Do you want to make a one to one comparison? How would you handle UUIDs?
 
-A test creating 101 talks can be slow. It tests an edge case. There is a trick: create a new TestCase Class, and set an attribute ``level`` with the value of 2. This test will then only be run when you run the tests with the argument ``-a 2`` or ``--all``
+A test creating 101 talks can be slow. It tests an edge case. There is a trick: create a new :py:class:`TestCase` Class, and set an attribute :py:attr:`level` with the value of 2.
+This test will then only be run when you run the tests with the argument :option:`-a 2` or :option:`--all`
 
 .. admonition:: Solution
    :class: toggle
@@ -186,19 +187,20 @@ Finally, we write a robot test:
 .. literalinclude:: ../ploneconf.site_sneak/chapters/03_zpt_p5/src/ploneconf/site/tests/robot/test_talk.robot
     :linenos:
 
-When you run your tests, you might notice that the robot tests didn't run. This is a feature activated by the robot layer, because robot tests can be quite slow. If you run your tests with ``./bin/test --all``
+When you run your tests, you might notice that the robot tests didn't run. This is a feature activated by the robot layer, because robot tests can be quite slow. If you run your tests with :command:`./bin/test --all`
 your robot tests will run. Now you will realize that you cannot work any more because a browser window pops up all the time.
 
 There are 3 possible workarounds:
 
 - install the headless browser, Phantomjs.
-  Then run the tests with an environment variable ``ROBOT_BROWSER=phantomjs bin/test --all`` This did not work for me btw.
-- Install xvfb, a framebuffer. You wont see the browser then. After installing, start xvfb like this: ``Xvfb :99.0 -screen 0 1024x768x24``. Then run your tests, declaring to connect to the non default X Server: ``DISPLAY=:99.0 bin/test --all``
+  Then run the tests with an environment variable :command:`ROBOT_BROWSER=phantomjs bin/test --all` This did not work for me btw.
+- Install :program:`xvfb`, a framebuffer. You wont see the browser then. After installing, start xvfb like this: :command:`Xvfb :99.0 -screen 0 1024x768x24`. Then run your tests, declaring to connect to the non-default X Server: :command:`DISPLAY=:99.0 bin/test --all`
 - Install Xephyr, it is also a framebuffer, but visible in a window. Start it the same way as you start Xvfb.
 
 The first method, with Phantomjs, will throw failures with our tests, unfortunately.
 
-For debugging, you can run the test like this ``ROBOT_SELENIUM_RUN_ON_FAILURE=Debug bin/test --all``. This will stop the test at the first failure and you end up in an interactive shell where you can try various Robot Framework commands.
+For debugging, you can run the test like this :command:`ROBOT_SELENIUM_RUN_ON_FAILURE=Debug bin/test --all`.
+This will stop the test at the first failure and you end up in an interactive shell where you can try various Robot Framework commands.
 
 More information
 ----------------

--- a/mastering_plone/thirdparty_behaviors.rst
+++ b/mastering_plone/thirdparty_behaviors.rst
@@ -13,7 +13,7 @@ Using Third-Party Behaviors
 Add teaser with collective.behavior.banner
 ------------------------------------------
 
-There are a lot of add-ons in Plone for sliders/banners/teasers. We thought there should be a better one and created ``collective.behavior.banner``.
+There are a lot of add-ons in Plone for sliders/banners/teasers. We thought there should be a better one and created :py:mod:`collective.behavior.banner`.
 
 .. figure:: ../_static/standards.png
    :align: center
@@ -39,7 +39,7 @@ After adding the source, we need to add the egg to buildout:
         collective.behavior.banner
         ...
 
-And rerun ``./bin/buildout``
+And rerun :file:`./bin/buildout`
 
 * Install the add-on
 * Create a new dexterity content type ``Banner`` with **only** the behavior ``Banner`` enabled.

--- a/mastering_plone/user_generated_content.rst
+++ b/mastering_plone/user_generated_content.rst
@@ -56,15 +56,15 @@ A custom workflow for talks
 
 We still need to fix a problem: Authenticated users can see all talks, even the ones of other users in the private state. Since we don't want this we will create a modified workflow for talks. The new workflow will only let them see and edit talks they created themselves and not the ones of other users.
 
-* Go to the ZMI > portal_workflow
-* See how talks have the same workflow as most content ``(Default)``
-* Go to the tab *Contents*, check the box next to ``simple_publication_workflow``, click ``copy`` and ``paste``.
+* Go to the ZMI > :guilabel:`portal_workflow`
+* See how talks have the same workflow as most content, namely :guilabel:`(Default)`
+* Go to the tab :guilabel:`Contents`, check the box next to :guilabel:`simple_publication_workflow`, click :guilabel:`copy` and :guilabel:`paste`.
 * Rename the new workflow from *copy_of_simple_publication_workflow* to *talks_workflow*.
 * Edit the workflow by clicking on it: Change the Title to *Talks Workflow*.
-* Click on the tab *States* and click on *private* to edit this state. In the next view select the tab *Permissions*.
-* Find the table column for the role *Contributor* and remove the permissions for ``Access contents information`` and ``View``. Note that the *Owner* (i.e. the Creator) still has some permissions.
-* Do the same for the state *pending*
-* Go back to *portal_workflow* and set the new workflow ``talks_workflow`` for talks. Click *Change* and then *Update security settings*.
+* Click on the tab :guilabel:`States` and click on :guilabel:`private` to edit this state. In the next view select the tab :guilabel:`Permissions`.
+* Find the table column for the role :guilabel:`Contributor` and remove the permissions for :guilabel:`Access contents information` and :guilabel:`View`. Note that the :guilabel:`Owner` (i.e. the Creator) still has some permissions.
+* Do the same for the state :guilabel:`pending`
+* Go back to :file:`portal_workflow` and set the new workflow :file:`talks_workflow` for talks. Click :file:`Change` and then :file:`Update security settings`.
 
 .. note::
 
@@ -84,14 +84,14 @@ Import/Export the Workflow
 **************************
 
 * export the GenericSetup step *Workflow Tool* in http://localhost:8080/Plone/portal_setup/manage_exportSteps.
-* drop the file ``workflows.xml`` into ``profiles/default``.
-* drop ``workflows/talks_workflow/definition.xml`` in ``profiles/default/workflows/talks_workflow/definition.xml``. The others are just definitions of the default-workflows and we only want things in our package that changes Plone.
+* drop the file :file:`workflows.xml` into :file:`profiles/default`.
+* drop :file:`workflows/talks_workflow/definition.xml` in :file:`profiles/default/workflows/talks_workflow/definition.xml`. The others are just definitions of the default-workflows and we only want things in our package that changes Plone.
 
 
 Enable self-registration
 ************************
 
-To enable self-registration add the following to ``profiles/default/registry.xml``:
+To enable self-registration add the following to :file:`profiles/default/registry.xml`:
 
 ..  code-block:: xml
 
@@ -113,7 +113,7 @@ So let's make sure some initial content is created and configured on installing 
 
 To run arbitrary code during the installation of a package we use a special import step, a `setuphandler <http://docs.plone.org/develop/addons/components/genericsetup.html#custom-installer-code-setuphandlers-py>`_
 
-Our package already has such an import step registered in ``configure.zcml``. It will be automatically run when (re-)installing the add-on.
+Our package already has such an import step registered in :file:`configure.zcml`. It will be automatically run when (re-)installing the add-on.
 
 ..  code-block:: xml
     :linenos:
@@ -127,9 +127,9 @@ Our package already has such an import step registered in ``configure.zcml``. It
 
 .. note::
 
-    All GenericSetup import steps, including this one, are run for **every add-on product** when they are installed. To make sure that it is only run during installation of your package the code checks for a marker text file ``ploneconfsite_default.txt``.
+    All GenericSetup import steps, including this one, are run for **every add-on product** when they are installed. To make sure that it is only run during installation of your package the code checks for a marker text file :file:`ploneconfsite_default.txt`.
 
-This step makes sure the method ``post_install`` in ``setuphandlers.py`` is executed on installation.
+This step makes sure the method :py:meth:`post_install` in :file:`setuphandlers.py` is executed on installation.
 
 ..  code-block:: python
     :linenos:
@@ -191,18 +191,18 @@ You'd usually create a list of dictionaries containing the type, parent and titl
 
 ..  note::
 
-    You can also export and later import content using the GenericSetup step *Content* (``Products.CMFCore.exportimport.content.exportSiteStructure``) although you cannot set all types of properties (workflow state, layout) and the syntax is a little special.
+    You can also export and later import content using the GenericSetup step *Content* (:py:meth:`Products.CMFCore.exportimport.content.exportSiteStructure`) although you cannot set all types of properties (workflow state, layout) and the syntax is a little special.
 
 
 Exercise 1
 ++++++++++
 
-Create a profile ``content`` that runs its own method in ``setuphandlers.py``. Note that you need a different marker text file to make sure your code is only run when installing the profile ``content``.
+Create a profile ``content`` that runs its own method in :file:`setuphandlers.py`. Note that you need a different marker text file to make sure your code is only run when installing the profile ``content``.
 
 ..  admonition:: Solution
     :class: toggle
 
-    Register the profile and the upgrade step in ``configure.zcml``
+    Register the profile and the upgrade step in :file:`configure.zcml`
 
     .. code-block:: xml
 
@@ -222,9 +222,9 @@ Create a profile ``content`` that runs its own method in ``setuphandlers.py``. N
             <depends name='typeinfo' />
         </genericsetup:importStep>
 
-    Create the profile folder ``profiles/content`` and drop a marker file ``ploneconfsite_content_marker.txt`` in it.
+    Create the profile folder :file:`profiles/content` and drop a marker file :file:`ploneconfsite_content_marker.txt` in it.
 
-    Also add a ``profiles/content/metadata.xml`` so the default profile gets automatically installed when installing the content profile.
+    Also add a :file:`profiles/content/metadata.xml` so the default profile gets automatically installed when installing the content profile.
 
     ..  code-block:: xml
 
@@ -236,7 +236,7 @@ Create a profile ``content`` that runs its own method in ``setuphandlers.py``. N
         </metadata>
 
 
-    Add the structure you wish to create as a list of dictionaries in ``setuphandlers.py``:
+    Add the structure you wish to create as a list of dictionaries in :file:`setuphandlers.py`:
 
     ..  code-block:: python
         :linenos:
@@ -313,7 +313,7 @@ Create a profile ``content`` that runs its own method in ``setuphandlers.py``. N
         ]
 
 
-    Add the method ``content`` to ``setuphandlers.py``. We pointed to that when registering the import step. And add some fancy logic to create the content from ``STRUCTURE``.
+    Add the method :py:meth:`content` to :file:`setuphandlers.py`. We pointed to that when registering the import step. And add some fancy logic to create the content from ``STRUCTURE``.
 
     ..  code-block:: python
         :linenos:
@@ -374,4 +374,4 @@ Create a profile ``content`` that runs its own method in ``setuphandlers.py``. N
             behavior.setLocallyAllowedTypes(allowed_types)
             behavior.setImmediatelyAddableTypes(allowed_types)
 
-    A huge benefit of this implementation is that you can add any object-attribute as a new item to ``item_dict``. ``plone.api.content.create`` will then set these on the new objects. This way you can also populate fields like ``text`` (using ``plone.app.textfield.RichTextValue``) or ``image`` (using ``plone.namedfile.file.NamedBlobImage``).
+    A huge benefit of this implementation is that you can add any object-attribute as a new item to :py:data:`item_dict`. :py:meth:`plone.api.content.create` will then set these on the new objects. This way you can also populate fields like :py:attr:`text` (using :py:class:`plone.app.textfield.RichTextValue`) or :py:attr:`image` (using :py:class:`plone.namedfile.file.NamedBlobImage`).

--- a/mastering_plone/viewlets_1.rst
+++ b/mastering_plone/viewlets_1.rst
@@ -27,7 +27,7 @@ A viewlet for the social behavior
 
 .. only:: not presentation
 
-    A viewlet is not a view but a snippet of html and logic that can be put in various places in the site. These places are called ``viewletmanager``.
+    A viewlet is not a view but a snippet of HTML and logic that can be put in various places in the site. These places are called ``viewletmanager``.
 
 * Inspect existing viewlets and their managers by going to http://localhost:8080/Plone/@@manage-viewlets.
 * We already customized a viewlet (:file:`colophon.pt`). Now we add a new one.
@@ -63,10 +63,10 @@ We register the viewlet in :file:`browser/configure.zcml`.
 .. only:: not presentation
 
     This registers a viewlet called ``social``.
-    It is visible on all content that implements the interface ``ISocial`` from our behavior.
+    It is visible on all content that implements the interface :py:class:`ISocial` from our behavior.
     It is also good practice to bind it to a specific ``layer``, so it only shows up if our add-on is actually installed.  We will return to this in a later chapter.
 
-The viewlet class ``SocialViewlet`` is expected in a file ``browser/viewlets.py``.
+The viewlet class :py:class:`SocialViewlet` is expected in a file :file:`browser/viewlets.py`.
 
 .. _BrowserLayer: http://docs.plone.org/develop/plone/views/layers.html?highlight=browserlayer#introduction
 
@@ -101,9 +101,9 @@ Let's add the missing template :file:`templates/social_viewlet.pt`.
 
 .. only:: not presentation
 
-    As you can see this is not a valid html document. That is not needed, because we don't want a complete view here, just a html snippet.
+    As you can see this is not a valid HTML document. That is not needed, because we don't want a complete view here, just a html snippet.
 
-    There is a tal define statement, querying for ``view/lanyrd_link``. Same as for views, viewlets have access to their class in page templates, as well.
+    There is a :samp:`tal:define` statement, querying for :samp:`view/lanyrd_link`. Same as for views, viewlets have access to their class in page templates, as well.
 
 We have to extend the Social Viewlet now to add the missing attribute:
 
@@ -117,7 +117,7 @@ We have to extend the Social Viewlet now to add the missing attribute:
           #. It makes it clear that we only want to use the ISocial aspect of the object
           #. If we decide to use a factory, for example to store our attributes in an annotation, we would `not` get back our context, but the adapter.
 
-        Therefore in this example you could simply write ``return self.context.lanyrd``.
+        Therefore in this example you could simply write :samp:`return self.context.lanyrd`.
 
 .. code-block:: python
     :linenos:
@@ -144,7 +144,7 @@ So far, we
 Exercise 1
 ----------
 
-Register a viewlet 'number_of_talks' in the footer that is only visible to admins (the permission you are looking for is ``cmf.ManagePortal``). Use only a template (no class) to display the number of talks already submitted. Hint: Use Acquisition to get the catalog (You know, you should not do this but there is plenty of code out there that does it...)
+Register a viewlet 'number_of_talks' in the footer that is only visible to admins (the permission you are looking for is :py:class:`cmf.ManagePortal`). Use only a template (no class) to display the number of talks already submitted. Hint: Use Acquisition to get the catalog (You know, you should not do this but there is plenty of code out there that does it...)
 
 ..  admonition:: Solution
     :class: toggle
@@ -163,7 +163,7 @@ Register a viewlet 'number_of_talks' in the footer that is only visible to admin
           />
 
 
-    For the ``for`` and ``layer``-parameters ``*`` is shorthand for ``zope.interface.Interface`` and the same effect as omitting them: The viewlet will be shown for all types of pages and for all Plone sites within your Zope instance.
+    For the ``for`` and ``layer``-parameters ``*`` is shorthand for :py:class:`zope.interface.Interface` and the same effect as omitting them: The viewlet will be shown for all types of pages and for all Plone sites within your Zope instance.
 
     Add the template :file:`browser/templates/number_of_talks.pt`:
 
@@ -175,9 +175,9 @@ Register a viewlet 'number_of_talks' in the footer that is only visible to admin
             There are <span tal:replace="talks" /> talks.
         </div>
 
-    ``python:context.portal_catalog`` will return the catalog through Acquisition. Be careful if you want to use path expressions: ``content/portal_catalog`` calls the catalog (and returns all brains). You need to prevent this by using ``nocall:content/portal_catalog``.
+    :samp:`python:context.portal_catalog` will return the catalog through Acquisition. Be careful if you want to use path expressions: :samp:`content/portal_catalog` calls the catalog (and returns all brains). You need to prevent this by using :samp:`nocall:content/portal_catalog`.
 
-    Relying on Acquisition is a bad idea. It would be much better to use the helper view ``plone_tools`` from ``plone/app/layout/globals/tools.py`` to get the catalog.
+    Relying on Acquisition is a bad idea. It would be much better to use the helper view ``plone_tools`` from :file:`plone/app/layout/globals/tools.py` to get the catalog.
 
     ..  code-block:: html
 
@@ -187,7 +187,7 @@ Register a viewlet 'number_of_talks' in the footer that is only visible to admin
             There are <span tal:replace="talks" /> talks.
         </div>
 
-    ``context/@@plone_tools/catalog`` traverses to the view ``plone_tools`` and calls its method ``catalog``. In python it would look like this:
+    :samp:`context/@@plone_tools/catalog` traverses to the view ``plone_tools`` and calls its method :py:meth:`catalog`. In python it would look like this:
 
     ..  code-block:: html
 
@@ -197,7 +197,8 @@ Register a viewlet 'number_of_talks' in the footer that is only visible to admin
             There are <span tal:replace="talks" /> talks.
         </div>
 
-    It is not a good practice to query the catalog within a template since even simple logic like this should live in Python. But it is very powerful if you are debugging or need a quick and dirty solution.
+    It is not a good practice to query the catalog within a template since even simple logic like this should live in Python.
+    But it is very powerful if you are debugging or need a quick and dirty solution.
 
     In Plone 5 you could even write it like this:
 
@@ -224,7 +225,7 @@ Register a viewlet 'days_to_conference' in the header. Use a class and a templat
 ..  admonition:: Solution
     :class: toggle
 
-    In ``configure.zcml``:
+    In :file:`configure.zcml`:
 
     ..  code-block:: xml
 
@@ -238,7 +239,7 @@ Register a viewlet 'days_to_conference' in the header. Use a class and a templat
           permission="zope2.View"
           />
 
-    In ``viewlets.py``:
+    In :file:`viewlets.py`:
 
     ..  code-block:: python
 
@@ -258,7 +259,7 @@ Register a viewlet 'days_to_conference' in the header. Use a class and a templat
                 return arrow.get(CONFERENCE_START_DATE).humanize()
 
 
-    And in ``templates/days_to_conference.pt``:
+    And in :file:`templates/days_to_conference.pt`:
 
     ..  code-block:: html
 

--- a/mastering_plone/views_2.rst
+++ b/mastering_plone/views_2.rst
@@ -54,9 +54,9 @@ Let us have a look at the zcml and the code.
 
     </configure>
 
-We are adding a file called ``views.py`` in the ``browser`` folder.
+We are adding a file called :file:`views.py` in the :file:`browser` folder.
 
-``browser/views.py``
+:file:`browser/views.py`
 
 .. code-block:: python
     :linenos:
@@ -86,24 +86,24 @@ We are adding a file called ``views.py`` in the ``browser`` folder.
             # def __call__(self):
             #    return self.template()
 
-Do you remember the term MultiAdapter? The browser page is just a MultiAdapter. The ZCML statement ``browser:page`` registers a MultiAdapter and adds additional things needed for a browser view.
+Do you remember the term :py:class:`MultiAdapter`? The browser page is just a MultiAdapter. The ZCML statement :samp:`browser:page` registers a :py:class:`MultiAdapter` and adds additional things needed for a browser view.
 
-An adapter adapts things, a MultiAdapter adapts multiple things.
+An adapter adapts things, a :py:class:`MultiAdapter` adapts multiple things.
 
 When you enter a url, Zope tries to find an object for it. At the end, when Zope does not find any more objects but there is still a path item left, or there are no more path items, Zope looks for an adapter that will reply to the request.
 
 The adapter adapts the request and the object that Zope found with the URL. The adapter class gets instantiated with the objects to be adapted, then it gets called.
 
-The code above does the same thing that the standard implementation would do. It makes ``context`` and ``request`` available as variables on the object.
+The code above does the same thing that the standard implementation would do. It makes :py:attr:`context` and :py:attr:`request` available as variables on the object.
 
 I have written down these methods because it is important to understand some important concepts.
 
-The ``__init__`` method gets called while Zope is still *trying* to find a view. At that phase, the security has not been resolved. Your code is not security checked. For historical reasons, many errors that happen in the ``__init__`` method can result in a page not found error instead of an exception.
+The :py:meth:`__init__` method gets called while Zope is still *trying* to find a view. At that phase, the security has not been resolved. Your code is not security checked. For historical reasons, many errors that happen in the :py:meth:`__init__` method can result in a page not found error instead of an exception.
 
-Use the ``__init__`` method to do as little as possible, if at all. Instead, you have the guarantee that the ``__call__`` method is called before anything else (but after the ``__init__`` method). It has the security checks in place and so on.
+Use the :py:meth:`__init__` method to do as little as possible, if at all. Instead, you have the guarantee that the :py:meth:`__call__` method is called before anything else (but after the :py:meth:`__init__` method). It has the security checks in place and so on.
 
-From a practical standpoint, consider the ``__call__`` method your ``__init__`` method, the biggest difference is that this method is supposed to return the html already.
-Let your base class handle the html generation.
+From a practical standpoint, consider the :py:meth:`__call__` method your :py:meth:`__init__` method, the biggest difference is that this method is supposed to return the HTML already.
+Let your base class handle the HTML generation.
 
 
 
@@ -113,9 +113,9 @@ Let your base class handle the html generation.
 The default view
 ----------------
 
-Now we finally add the default view for talks in views.py
+Now we finally add the default view for talks in :file:`views.py`
 
-``browser/configure.zcml``
+:file:`browser/configure.zcml`
 
 .. code-block:: xml
 
@@ -128,7 +128,7 @@ Now we finally add the default view for talks in views.py
        permission="zope2.View"
        />
 
-``browser/views.py``
+:file:`browser/views.py`
 
 .. code-block:: python
 
@@ -140,19 +140,19 @@ Now we finally add the default view for talks in views.py
         """ The default view for talks
         """
 
-The DefaultView base class in plone.dexterity only exists for Dexterity Objects and has some very useful properties available to the template:
+The :py:class:`DefaultView` base class in :py:mod:`plone.dexterity` only exists for Dexterity Objects and has some very useful properties available to the template:
 
-* ``view.w`` is a dictionary of all the display widgets, keyed by field names. This includes widgets from alternative fieldsets.
-* ``view.widgets`` contains a list of widgets in schema order for the default fieldset.
-* ``view.groups`` contains a list of fieldsets in fieldset order.
-* ``view.fieldsets`` contains a dict mapping fieldset name to fieldset
+* :py:attr:`view.w` is a dictionary of all the display widgets, keyed by field names. This includes widgets from alternative fieldsets.
+* :py:attr:`view.widgets` contains a list of widgets in schema order for the default fieldset.
+* :py:attr:`view.groups` contains a list of fieldsets in fieldset order.
+* :py:attr:`view.fieldsets` contains a dict mapping fieldset name to fieldset
 * On a fieldset (group), you can access a widget list to get widgets in that fieldset
 
 .. note::
 
     ``plone.dexterity.browser.view.DefaultView`` has the same features as the grok equivalent ``plone.directives.dexterity.DisplayForm``.
 
-The template ``templates/talkview.pt`` uses the pattern ``view/w/<fieldname>/render`` to render some widgets.
+The template :file:`templates/talkview.pt` uses the pattern :samp:`view/w/<fieldname>/render` to render some widgets.
 
 .. code-block:: xml
     :linenos:
@@ -181,7 +181,7 @@ We should tell Plone that the talkview should be used as the default view for ta
 
 This is a configuration that you can change during runtime and is stored in the database, as such it is also managed by GenericSetup profiles.
 
-open ``profiles/default/types/talk.xml``:
+open :file:`profiles/default/types/talk.xml`:
 
 .. code-block:: xml
     :linenos:
@@ -203,7 +203,7 @@ We will have to either reinstall our add-on or run the GenericSetup import step 
 
 Let's improve the talkview to show all the info we want.
 
-``templates/talkview.pt``:
+:file:`templates/talkview.pt`:
 
 .. code-block:: xml
     :linenos:

--- a/mastering_plone/views_3.rst
+++ b/mastering_plone/views_3.rst
@@ -139,7 +139,7 @@ We could also add a new index to the catalog that will add 'audience' to the pro
         def talk_audience(object, **kw):
              return object.audience
 
-    We'd have to register this factory function as a named adapter in the ``configure.zcml``. Assuming you've put the code above into a file named indexers.py
+    We'd have to register this factory function as a named adapter in the :file:`configure.zcml`. Assuming you've put the code above into a file named :file:`indexers.py`
 
     .. code-block:: xml
 
@@ -149,7 +149,7 @@ We could also add a new index to the catalog that will add 'audience' to the pro
 
 Why use the catalog at all? It checks for permissions, and only returns the talks that the current user may see. They might be private or hidden to you since they are part of a top secret conference for core developers (there is no such thing!).
 
-Most objects in plone act like dictionaries, so you can do ``context.values()`` to get all its contents.
+Most objects in Plone act like dictionaries, so you can do :py:meth:`context.values()` to get all its contents.
 
 For historical reasons some attributes of brains and objects are written differently.
 
@@ -166,7 +166,7 @@ For historical reasons some attributes of brains and objects are written differe
     >>> brain.title == obj.title
     False
 
-Who can guess what ``brain.title`` will return since the brain has no such attribute?
+Who can guess what :py:attr:`brain.title` will return since the brain has no such attribute?
 
 .. only:: not presentation
 
@@ -174,7 +174,7 @@ Who can guess what ``brain.title`` will return since the brain has no such attri
 
         Answer: Acquisition will get the attribute from the nearest parent. ``brain.__parent__`` is ``<CatalogTool at /Plone/portal_catalog>``. The attribute ``title`` of the ``portal_catalog`` is 'Indexes all content in the site'.
 
-Acquisition can be harmful. Brains have no attribute 'getLayout' ``brain.getLayout()``:
+Acquisition can be harmful. Brains have no attribute 'getLayout' :py:meth:`brain.getLayout()`:
 
 .. code-block:: pycon
 
@@ -235,7 +235,7 @@ Since you now know how to query the catalog it is time for some exercise.
 Exercise 1
 **********
 
-Add a method ``get_news`` to ``TalkListView`` that returns a list of brains of all News Items that are published and sort them in the order of their publishing-date.
+Add a method :py:meth:`get_news` to :py:class:`TalkListView` that returns a list of brains of all News Items that are published and sort them in the order of their publishing-date.
 
 ..  admonition:: Solution
     :class: toggle
@@ -315,7 +315,7 @@ The view and the controller are very much mixed in Plone. Especially when you lo
 
 But you should nevertheless do it! You'll end up with more than enough logic in the templates anyway.
 
-Add this simple table to ``templates/talklistview.pt``:
+Add this simple table to :file:`templates/talklistview.pt`:
 
 .. code-block:: html
     :linenos:
@@ -349,7 +349,7 @@ Add this simple table to ``templates/talklistview.pt``:
         </tbody>
     </table>
 
-Afterwards you transform it into a listing. Here we use one of many nice features built into Plone. The ``class="pat-tablesorter"`` (before Plone 5 that was ``class="listing"``) gives the table a nice style and makes the table sortable with some javascript.
+Afterwards you transform it into a listing. Here we use one of many nice features built into Plone. The :samp:`class="pat-tablesorter"` (before Plone 5 that was :samp:`class="listing"`) gives the table a nice style and makes the table sortable with some JavaScript.
 
 .. code-block:: html
     :linenos:
@@ -395,14 +395,14 @@ Afterwards you transform it into a listing. Here we use one of many nice feature
 
 There are some some things that need explanation:
 
-``tal:repeat="talk view/talks"``
-    This iterates over the list of dictionaries returned by the view. ``view/talks`` calls the method ``talks`` of our view and each ``talk`` is in turn one of the dictionaries that are returned by this method. Since TAL's path expressions for the lookup of values in dictionaries is the same as for the attributes of objects we can write ``talk/somekey`` as we could ``view/somemethod``. Handy but sometimes irritating since from looking at the page template alone we often have no way of knowing if something is an attribute, a method or the value of a dict. It would be a good practice to write ``tal:repeat="talk python:view.talks()"``.
+:samp:`tal:repeat="talk view/talks"`
+    This iterates over the list of dictionaries returned by the view. :samp:`view/talks` calls the method :py:meth:`talks` of our view and each :py:obj:`talk` is in turn one of the dictionaries that are returned by this method. Since TAL's path expressions for the lookup of values in dictionaries is the same as for the attributes of objects we can write :samp:`talk/somekey` as we could :samp:`view/somemethod`. Handy but sometimes irritating since from looking at the page template alone we often have no way of knowing if something is an attribute, a method or the value of a dict. It would be a good practice to write :samp:`tal:repeat="talk python:view.talks()"`.
 
-``tal:content="talk/speaker"``
-    'speaker' is a key in the dict 'talk'. We could also write ``tal:content="python:talk['speaker']"``
+:samp:`tal:content="talk/speaker"`
+    'speaker' is a key in the dict 'talk'. We could also write :samp:`tal:content="python:talk['speaker']"`
 
-``tal:condition="not:view/talks"``
-    This is a fallback if no talks are returned. It then returns an empty list (remember ``results = []``?)
+:samp:`tal:condition="not:view/talks"`
+    This is a fallback if no talks are returned. It then returns an empty list (remember :samp:`results = []`?)
 
 
 Exercise
@@ -455,7 +455,7 @@ Modify the view to only use python expressions.
             </tbody>
         </table>
 
-    To follow the mantra "don't repeat yourself" we define ``talks`` instead of calling the method twice.
+    To follow the mantra "don't repeat yourself" we define :py:obj:`talks` instead of calling the method twice.
 
 
 .. _views3-custom-label:
@@ -463,11 +463,11 @@ Modify the view to only use python expressions.
 Setting a custom view as default view on an object
 --------------------------------------------------
 
-We don't want to always have to append /@@talklistview to our folder to get the view. There is a very easy way to set the view to the folder using the ZMI.
+We don't want to always have to append :samp:`/@@talklistview` to our folder to get the view. There is a very easy way to set the view to the folder using the ZMI.
 
-If we append ``/manage_propertiesForm`` we can set the property "layout" to ``talklistview``.
+If we append :samp:`/manage_propertiesForm` we can set the property "layout" to :samp:`talklistview`.
 
-To make views configurable so that editors can choose them we have to register the view for the content type at hand in its FTI. To enable it for all folders we add a new file ``profiles/default/types/Folder.xml``
+To make views configurable so that editors can choose them we have to register the view for the content type at hand in its FTI. To enable it for all folders we add a new file :file:`profiles/default/types/Folder.xml`
 
 .. code-block:: xml
     :linenos:
@@ -481,7 +481,7 @@ To make views configurable so that editors can choose them we have to register t
 
 After re-applying the typeinfo profile of our add-on (or simply reinstalling it) the content type "Folder" is extended with our additional view method and appears in the display dropdown.
 
-The ``purge="False"`` appends the view to the already existing ones instead of replacing them.
+The :samp:`purge="False"` appends the view to the already existing ones instead of replacing them.
 
 
 .. _views3-summary-label:

--- a/mastering_plone/zpt.rst
+++ b/mastering_plone/zpt.rst
@@ -64,7 +64,7 @@ results in:
 
     <p>I love red</p>
 
-Let's try it. Open the file ``training.pt`` and add:
+Let's try it. Open the file :file:`training.pt` and add:
 
 .. code-block:: html
 
@@ -124,7 +124,7 @@ We used three TAL-Attributes here. This is the complete list of TAL-attributes:
     replace the content of an element. We replaced the default content above with "An even better conference"
 
 ``tal:attributes``
-    dynamically change element attributes. We set the html attribute ``href`` to the value of the variable ``a_fine_url``
+    dynamically change element attributes. We set the HTML attribute ``href`` to the value of the variable ``a_fine_url``
 
 ``tal:condition``
     tests whether the expression is true or false, and outputs or omits the element accordingly.
@@ -237,9 +237,10 @@ path expressions
 
 Regarding TALES so far we used ``string:`` or ``python:`` or only variables. The next and most common expression are path expressions. Optionally you can start a path expression with ``path:``
 
-Every path expression starts with a variable name. It can either be an object like ``context``, ``view`` or ``template`` or a variable defined earlier like ``talk``.
+Every path expression starts with a variable name. It can either be an object like :py:obj:`context`, :py:obj:`view` or :py:obj:`template` or a variable defined earlier like :py:data:`talk`.
 
-After the variable we add a slash ``/`` and the name of a sub-object, attribute or callable. The '/' is used to end the name of an object and the start of the property name. Properties themselves may be objects that in turn have properties.
+After the variable we add a slash ``/`` and the name of a sub-object, attribute or callable.
+The ``/`` is used to end the name of an object and the start of the property name. Properties themselves may be objects that in turn have properties.
 
 .. code-block:: html
 
@@ -537,7 +538,7 @@ Modify the following template and one by one solve the following problems:
         </table>
 
 
-2. Turn the title in a link to the url of the talk if there is one.
+2. Turn the title in a link to the URL of the talk if there is one.
 
 ..  admonition:: Solution
     :class: toggle
@@ -577,7 +578,7 @@ Modify the following template and one by one solve the following problems:
             </tr>
         </table>
 
-3. If there is no url turn it into a link to a google search for that talk's title
+3. If there is no URL, turn it into a link to a google search for that talk's title:
 
 ..  admonition:: Solution
     :class: toggle
@@ -618,9 +619,9 @@ Modify the following template and one by one solve the following problems:
             </tr>
         </table>
 
-4. Add alternating the css classes 'odd' and 'even' to the <tr>. (``repeat.<name of item in loop>.odd`` is True if the ordinal index of the current iteration is an odd number)
+4. Add alternating the CSS classes 'odd' and 'even' to the <tr>. (:samp:`repeat.{<name of item in loop>}.odd` is True if the ordinal index of the current iteration is an odd number)
 
-   Use some css to prove your solution:
+   Use some CSS to test your solution:
 
    .. code-block:: css
 
@@ -868,7 +869,7 @@ Here also added the css-class `listing` to the table. It is one of many css-clas
 macros in browser views
 +++++++++++++++++++++++
 
-Define a macro in a new file ``macros.pt``
+Define a macro in a new file :file:`macros.pt`
 
 .. code-block:: html
 
@@ -887,7 +888,7 @@ Register it as a simple BrowserView in zcml:
       permission="zope2.View"
       />
 
-Reuse the macro in the template ``training.pt``:
+Reuse the macro in the template :file:`training.pt`:
 
 .. code-block:: html
 
@@ -920,13 +921,13 @@ In templates we can also access other browser views. Some of those exist to prov
                 plone_view context/@@plone;"
 
 ``@@plone_context_state``
-    The BrowserView ``plone.app.layout.globals.context.ContextState`` holds useful methods having to do with the current context object such as ``is_default_page``
+    The BrowserView :py:class:`plone.app.layout.globals.context.ContextState` holds useful methods having to do with the current context object such as :py:meth:`is_default_page`
 
 ``@@plone_portal_state``
-    The BrowserView ``plone.app.layout.globals.portal.PortalState`` holds methods for the portal like ``portal_url``
+    The BrowserView :py:class:`plone.app.layout.globals.portal.PortalState` holds methods for the portal like :py:meth:`portal_url`
 
 ``@@plone_tools``
-    The BrowserView ``plone.app.layout.globals.tools.Tools`` gives access to the most important tools like ``plone_tools/catalog``
+    The BrowserView :py:class:`plone.app.layout.globals.tools.Tools` gives access to the most important tools like ``plone_tools/catalog``
 
 These are very widely used and there are many more.
 

--- a/mastering_plone/zpt_2.rst
+++ b/mastering_plone/zpt_2.rst
@@ -35,19 +35,19 @@ We want to show the date a News Item is published. This way people can see at a 
 
 To do this we will customize the template that is used to render News Items.
 
-We use ``z3c.jbot`` for overriding templates. The package already has the necessary configuration in ``browser/configure.zcml``.
+We use :py:mod:`z3c.jbot` for overriding templates. The package already has the necessary configuration in :file:`browser/configure.zcml`.
 
-* Find the file ``newsitem.pt`` in ``packages/plone/app/contenttypes/browser/templates/`` (in vagrant this directory is in ``/home/vagrant/packages``, otherwise it is in your buildout directory).
-* Copy that file into the folder ``browser/overrides/`` of our package. If you use vagrant you'd have to use::
+* Find the file :file:`newsitem.pt` in :file:`packages/plone/app/contenttypes/browser/templates/` (in vagrant this directory is in :file:`/home/vagrant/packages`, otherwise it is in your buildout directory).
+* Copy that file into the folder :file:`browser/overrides/` of our package. If you use vagrant you'd have to use::
 
     cp /home/vagrant/packages/plone/app/contenttypes/browser/templates/newsitem.pt /vagrant/buildout/src/ploneconf.site/src/ploneconf/site/browser/overrides/
 
-* Rename the new file from ``newsitem.pt`` to ``plone.app.contenttypes.browser.templates.newsitem.pt``.
+* Rename the new file from :file:`newsitem.pt` to :file:`plone.app.contenttypes.browser.templates.newsitem.pt`.
 * Restart Plone
 
 Now Plone will use the new file to override the original one.
 
-Edit the new file ``plone.app.contenttypes.browser.templates.newsitem.pt`` and insert the following before the ``<div id="parent-fieldname-text"``...:
+Edit the new file :file:`plone.app.contenttypes.browser.templates.newsitem.pt` and insert the following before the ``<div id="parent-fieldname-text"``...:
 
 ..  code-block:: html
 
@@ -65,7 +65,7 @@ Since we use Plone 5 and Chameleon we could also write:
 
 * Open an existing news item in the browser
 
-This will show something like: ``2015-02-21T12:01:31+01:00``. Not very user-friendly. Let's extend the code and use one of many helpers plone offers.
+This will show something like: ``2015-02-21T12:01:31+01:00``. Not very user-friendly. Let's extend the code and use one of many helpers Plone offers.
 
 ..  code-block:: html
 
@@ -75,8 +75,8 @@ This will show something like: ``2015-02-21T12:01:31+01:00``. Not very user-frie
 
 This will render ``Feb 21, 2015``.
 
-* ``plone_view`` is the BrowserView ``Products.CMFPlone.browser.ploneview.Plone`` and it is defined in the ``main_template`` (Products/CMFPlone/browser/templates/main_template.pt) of Plone 5 like this ``plone_view context/@@plone;`` and thus always available.
-* The method ``toLocalizedTime`` runs a date object through Plone's ``translation_service`` and returns the Date in the current locales format, thus transforming ``2015-02-21T12:01:31+01:00`` to ``Feb 21, 2015``.
+* ``plone_view`` is the BrowserView :py:class:`Products.CMFPlone.browser.ploneview.Plone` and it is defined in the ``main_template`` (:file:`Products/CMFPlone/browser/templates/main_template.pt`) of Plone 5 like this ``plone_view context/@@plone;`` and thus always available.
+* The method :py:meth:`toLocalizedTime` runs a date object through Plone's ``translation_service`` and returns the Date in the current locales format, thus transforming ``2015-02-21T12:01:31+01:00`` to ``Feb 21, 2015``.
 
 The same in a slightly different style:
 
@@ -88,7 +88,7 @@ The same in a slightly different style:
             The current Date in its local short format
     </p>
 
-Here we first get the plone view and then the method ``toLocalizedTime`` and we use ``nocall:`` to prevent the method toLocalizedTime from being called, since we only want to make it available for later use.
+Here we first get the Plone view and then the method :py:meth:`toLocalizedTime` and we use ``nocall:`` to prevent the method :py:meth:`toLocalizedTime` from being called, since we only want to make it available for later use.
 
 .. note::
 
@@ -114,14 +114,14 @@ Now we should see the date in a user-friendly format like ``Today at 12:01 PM``.
 The Summary View
 ----------------
 
-We use the view "Summary View" to list news releases. They should also have the date. The template associated with that view is ``listing_summary.pt``.
+We use the view "Summary View" to list news releases. They should also have the date. The template associated with that view is :file:`listing_summary.pt`.
 
 Let's look for the template folder_summary_view.pt::
 
     plone/app/contenttypes/browser/templates/listing_summary.pt
 
 
-Copy it to ``browser/overrides/`` and rename it to ``plone.app.contenttypes.browser.templates.listing_summary.pt``.
+Copy it to :file:`browser/overrides/` and rename it to :file:`plone.app.contenttypes.browser.templates.listing_summary.pt`.
 
 Add the following after line 28:
 
@@ -139,15 +139,15 @@ The date is only displayed if the variable ``item_type`` is ``News Item``.
 
 Let's take a closer look at that template. How does it know that ``item_type`` is the name of the content type?
 
-The first step to uncovering that secret is line 14 of ``listing_summary.pt``:
+The first step to uncovering that secret is line 14 of :file:`listing_summary.pt`:
 
 .. code-block:: html
 
     <metal:block use-macro="context/@@listing_view/macros/entries">
 
-``use-macro`` tells Plone to reuse the macro ``entries`` from the view ``listing_view``. That view is defined in ``packages/plone/app/contenttypes/browser/configure.zcml``.  It uses the template ``plone/app/contenttypes/browser/templates/listing.pt``. That makes overriding that much easier :-)
+``use-macro`` tells Plone to reuse the macro ``entries`` from the view ``listing_view``. That view is defined in :file:`packages/plone/app/contenttypes/browser/configure.zcml`.  It uses the template :file:`plone/app/contenttypes/browser/templates/listing.pt`. That makes overriding that much easier :-)
 
-That template ``listing.pt`` defines the slot ``entries`` like this:
+That template :file:`listing.pt` defines the slot ``entries`` like this:
 
 ..  code-block:: xml
 
@@ -179,7 +179,7 @@ Here the ``item_type`` is defined as ``item_type item/PortalType``. Let's dig a 
 
 ``tal:repeat="item batch"`` tells the template to iterate over an iterable ``batch`` which is defined as ``batch view/batch``.
 
-``view`` is always the BrowserView for which the template is registered. In our case this is either ``plone.app.contenttypes.browser.collection.CollectionView`` if you called that view on a collection, or ``plone.app.contenttypes.browser.folder.FolderView`` for folders. You might remember that both are defined in ``configure.zcml``
+``view`` is always the BrowserView for which the template is registered. In our case this is either :py:class:`plone.app.contenttypes.browser.collection.CollectionView` if you called that view on a collection, or :py:class:`plone.app.contenttypes.browser.folder.FolderView` for folders. You might remember that both are defined in :file:`configure.zcml`
 
 Luckily the first is a class that inherits from the second:
 
@@ -187,16 +187,16 @@ Luckily the first is a class that inherits from the second:
 
     class CollectionView(FolderView):
 
-``batch`` is a method in ``FolderView`` that turns ``results`` into batches. ``results`` exists in both classes. This means, in case the item we are looking at is a collection the method ``results`` of ``CollectionView``, will be used and in case it's a folder the one in ``FolderView``.
+:py:meth:`batch` is a method in :py:class:`FolderView` that turns :py:obj:`results` into batches. :py:obj:`results` exists in both classes. This means, in case the item we are looking at is a collection, the method :py:meth:`results` of :py:class:`CollectionView`, will be used; and in case it's a folder, the one in :py:class:`FolderView`.
 
 To be continued...
 
 
 .. note::
 
-    In Plone 4 without ``plone.app.contenttypes`` the template to customize would be ``folder_summary_view.pt``, a skin template for Archetypes that can be found in the folder ``Products/CMFPlone/skins/plone_content/``. The customized template would be ``Products.CMFPlone.skins.plone_content.folder_summary_view.pt``.
+    In Plone 4 without :py:mod:`plone.app.contenttypes` the template to customize would be :file:`folder_summary_view.pt`, a skin template for Archetypes that can be found in the folder :file:`Products/CMFPlone/skins/plone_content/`. The customized template would be :file:`Products.CMFPlone.skins.plone_content.folder_summary_view.pt`.
 
-    The Archetypes template for News Items is ``newsitems_view.pt`` from the same folder. The customized template would then have to be named ``Products.CMFPlone.skins.plone_content.newsitems_view.pt``.
+    The Archetypes template for News Items is :file:`newsitems_view.pt` from the same folder. The customized template would then have to be named :file:`Products.CMFPlone.skins.plone_content.newsitems_view.pt`.
 
     Keep in mind that not only the names and locations have changed but also the content!
 
@@ -208,25 +208,27 @@ Finding the right template
 
 We changed the display of the listing of news items at http://localhost:8080/Plone/news. But how do we know which template to customize?
 
-If you don't know which template is used by the page you're looking at you can make an educated guess, start a debug session or use ``plone.app.debugtoolbar``.
+If you don't know which template is used by the page you're looking at you can make an educated guess, start a debug session or use :py:mod:`plone.app.debugtoolbar`.
 
-1.  We could check the html with firebug and look for a structure in the content area that looks unique. We could also look for the css class of the body
+1.  We could check the HTML with Firebug and look for a structure in the content area that looks unique. We could also look for the CSS class of the body
 
     .. code-block:: html
 
         <body class="template-summary_view portaltype-collection site-Plone section-news subsection-aggregator icons-on userrole-anonymous" dir="ltr">
 
-    The class ``template-summary_view`` tells us that the name of the view (but not necessarily the name of the template) is ``summary_view``. So we could search all ``*.zcml``-Files for ``name="summary_view"`` or search all templates called ``summary_view.pt`` and probably find the view and also the corresponding template. But only probably because it would not tell us if the template is already being overridden.
+    The class ``template-summary_view`` tells us that the name of the view (but not necessarily the name of the template) is ``summary_view``. So we could search all :file:`*.zcml`-Files for ``name="summary_view"`` or search all templates called :file:`summary_view.pt` and probably find the view and also the corresponding template. But only probably because it would not tell us if the template is already being overridden.
 
-2.  The safest method is using ``plone.app.debugtoolbar``.  We already have it in our buildout and only need to install it. It adds a "Debug"-Dropdown on top of the page. The Section "Published" shows the complete path to the template that is used to render the page you are seeing.
+2.  The safest method is using :py:mod:`plone.app.debugtoolbar`.  We already have it in our buildout and only need to install it. It adds a "Debug"-Dropdown on top of the page. The Section "Published" shows the complete path to the template that is used to render the page you are seeing.
 
     .. warning::
 
        plone.app.debugtoolbar is not yet compatible with Plone 5. It kind of works but looks really ugly...
 
-3.  The debug session to find the template is a little more complicated. Since we have ``Products.PDBDebugMode`` in our buildout we can call ``/pdb`` on our page.
+3.  The debug session to find the template is a little more complicated. Since we have :py:mod:`Products.PDBDebugMode` in our buildout we can call ``/pdb`` on our page.
 
-    The object that the url points to is by default ``self.context``. But the first problem is that the url we're seeing is not the url of the collection where we want to modify since the collection is the default page of the folder ``news``.
+    The object that the URL points to is by default :py:obj:`self.context`.
+    But the first problem is that the URL we're seeing is not the URL of the collection we want to modify.
+    This is because the collection is the default page of the folder ``news``.
 
     .. code-block:: python
 
@@ -247,7 +249,7 @@ If you don't know which template is used by the page you're looking at you can m
 
     Now we see that we already customized the template.
 
-    Here is a method that could be used in a view or viewlet to display that path :
+    Here is a method that could be used in a view or viewlet to display that path:
 
     ..  code-block:: python
 
@@ -272,10 +274,10 @@ skin templates
 
     There is a deprecated technology called 'skin templates' that allows you to simply add some page template (e.g. 'old_style_template.pt') to a certain folder in the ZMI or your egg and you can access it in the browser by opening a url like http://localhost:8080/Plone/old_style_template and it will be rendered. But we don't use it and you too should not, even though these skin templates are still all over Plone.
 
-    Since we use ``plone.app.contenttypes`` we do not encounter many skin templates when dealing with content any more. But more often than not you'll have to customize an old site that still uses skin templates.
+    Since we use :py:mod:`plone.app.contenttypes` we do not encounter many skin templates when dealing with content any more. But more often than not you'll have to customize an old site that still uses skin templates.
 
-Skin templates and python scripts in portal_skins are deprecated because:
+Skin templates and Python scripts in ``portal_skins`` are deprecated because:
 
-* they use restricted python
-* they have no nice way to attach python code to them
+* they use restricted Python
+* they have no nice way to attach Python code to them
 * they are always callable for everything (they can't easily be bound to an interface)

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -280,7 +280,7 @@ Instead we use our own Plone instance during the training. It is in :file:`/vagr
         export LC_ALL=en_US.UTF-8
         export LANG=en_US.UTF-8
 
-Now the Zope instance we're using is running. You can stop the running instance anytime using :kdb:`ctrl + c`.
+Now the Zope instance we're using is running. You can stop the running instance anytime using :kbd:`ctrl + c`.
 
 If it doesn't, don't worry, your shell isn't blocked. Type :kbd:`reset` (even if you can't see the prompt) and press RETURN, and it should become visible again.
 

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -10,7 +10,7 @@ Keep in mind that you need a fast internet connection during installation since 
 
 .. warning::
 
-    If you feel the desire to try out both methods below (with Vagrant and without), make sure you use different ``training`` directories!  The two installations do not coexist well.
+    If you feel the desire to try out both methods below (with Vagrant and without), make sure you use different :file:`training` directories!  The two installations do not coexist well.
 
 
 Installing Plone without vagrant
@@ -107,7 +107,7 @@ If the output says ``INFO Zope Ready to handle requests`` then you are in busine
 
 If you point your browser at http://localhost:8080 you see that Plone is running. There is no Plone site yet - we will create one in chapter 6.
 
-Now you have a working Plone site up and running and can continue with the next chapter.  You can stop the running instance anytime using ``ctrl + c``.
+Now you have a working Plone site up and running and can continue with the next chapter.  You can stop the running instance anytime using :kbd:`ctrl + c`.
 
 .. warning::
 
@@ -142,7 +142,7 @@ Get the latest version from https://www.vagrantup.com/downloads.html for your op
 
     In Windows there is a bug in the recent version of Vagrant. Here are the instructions for how to work around the warning ``Vagrant could not detect VirtualBox! Make sure VirtualBox is properly installed``.
 
-Now your system has a command ``vagrant`` that you can run in the terminal.
+Now your system has a command :command:`vagrant` that you can run in the terminal.
 
 .. note::
 
@@ -153,7 +153,7 @@ First, create a directory in which you want to do the training.
 
 .. warning::
 
-    If you already have a ``training`` directory because you followed the **Installing Plone without vagrant** instructions above, you should either delete it, rename it, or use a different name below.
+    If you already have a :file:`training` directory because you followed the **Installing Plone without vagrant** instructions above, you should either delete it, rename it, or use a different name below.
 
 .. code-block:: bash
 
@@ -173,9 +173,9 @@ Now download :download:`plone_training_config.zip <../_static/plone_training_con
     $ wget https://raw.githubusercontent.com/plone/training/master/_static/plone_training_config.zip
     $ unzip plone_training_config.zip
 
-The training directory should now hold the file ``Vagrantfile`` and the directory ``manifests`` which again contains several files.
+The training directory should now hold the file :file:`Vagrantfile` and the directory :file:`manifests` which again contains several files.
 
-Now start setting up the VM that is configured in ``Vagrantfile``:
+Now start setting up the VM that is configured in :file:`Vagrantfile`:
 
 .. code-block:: bash
 
@@ -227,9 +227,9 @@ Once Vagrant finishes the provisioning process, you can login to the now running
 
     If you use Windows you'll have to login with `putty <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_. Connect to vagrant@127.0.01 at port 2222. User **and** password are ``vagrant``.
 
-You are now logged in as the user vagrant in ``/home/vagrant``. We'll do all steps of the training as this user.
+You are now logged in as the user vagrant in :file:`/home/vagrant`. We'll do all steps of the training as this user.
 
-Instead we use our own Plone instance during the training. It is in ``/vagrant/buildout/``. Start it in foreground with ``./bin/instance fg``.
+Instead we use our own Plone instance during the training. It is in :file:`/vagrant/buildout/`. Start it in foreground with :command:`./bin/instance fg`.
 
 .. code-block:: bash
 
@@ -280,13 +280,13 @@ Instead we use our own Plone instance during the training. It is in ``/vagrant/b
         export LC_ALL=en_US.UTF-8
         export LANG=en_US.UTF-8
 
-Now the Zope instance we're using is running. You can stop the running instance anytime using ``ctrl + c``.
+Now the Zope instance we're using is running. You can stop the running instance anytime using :kdb:`ctrl + c`.
 
-If it doesn't, don't worry, your shell isn't blocked. Type ``reset`` (even if you can't see the prompt) and press RETURN, and it should become visible again.
+If it doesn't, don't worry, your shell isn't blocked. Type :kbd:`reset` (even if you can't see the prompt) and press RETURN, and it should become visible again.
 
 If you point your local browser at http://localhost:8080 you see that Plone is running in vagrant. This works because VirtualBox forwards the port 8080 from the guest system (the vagrant Ubuntu) to the host system (your normal operating system).  There is no Plone site yet - we will create one in chapter 6.
 
-The Buildout for this Plone is in a shared folder.  This means we run it in the vagrant box from ``/vagrant/buildout`` but we can also access it in our own operating system and use our favorite editor. You will find the directory ``buildout`` in the directory ``training`` that you created in the very beginning next to ``Vagrantfile`` and ``manifests``.
+The Buildout for this Plone is in a shared folder.  This means we run it in the vagrant box from :file:`/vagrant/buildout` but we can also access it in our own operating system and use our favorite editor. You will find the directory :file:`buildout` in the directory :file:`training` that you created in the very beginning next to :file:`Vagrantfile` and :file:`manifests`.
 
 .. note::
 
@@ -310,6 +310,6 @@ Installation is done automatically by vagrant and puppet. If you want to know wh
 
     Keep in mind the following recommendations for using your Vagrant virtualboxes:
 
-    * Use the ``vagrant suspend`` or ``vagrant halt`` commands to put the virtualbox to "sleep" or to "power it off" before attempting to start another Plone instance anywhere else on your machine, if it uses the same port.  That's because vagrant "reserves" port 8080, and even if you stopped Plone in vagrant, that port is still in use by the guest OS.
-    * If you are done with a vagrant box, and want to delete it, always remember to run ``vagrant destroy`` on it before actually deleting the directory containing it.  Otherwise you'll leave its "ghost" in the list of boxes managed by vagrant and possibly taking up disk space on your machine.
-    * See ``vagrant help`` for all available commands, including ``suspend``, ``halt``, ``destroy``, ``up``, ``ssh`` and ``resume``.
+    * Use the :command:`vagrant suspend` or :command:`vagrant halt` commands to put the virtualbox to "sleep" or to "power it off" before attempting to start another Plone instance anywhere else on your machine, if it uses the same port.  That's because vagrant "reserves" port 8080, and even if you stopped Plone in vagrant, that port is still in use by the guest OS.
+    * If you are done with a vagrant box, and want to delete it, always remember to run :command:`vagrant destroy` on it before actually deleting the directory containing it.  Otherwise you'll leave its "ghost" in the list of boxes managed by vagrant and possibly taking up disk space on your machine.
+    * See :command:`vagrant help` for all available commands, including :command:`suspend`, :command:`halt`, :command:`destroy`, :command:`up`, :command:`ssh` and :command:`resume`.

--- a/plone_training_config/what_vagrant_does.rst
+++ b/plone_training_config/what_vagrant_does.rst
@@ -11,7 +11,7 @@ What Vagrant for example does is install a port forward so that ``http://localho
 
 Puppet is a configuration management tool (others you might have heard of are Chef, Ansible and SaltStack) and helps system admnistrators to automatically manage servers (real and virtual). We won't get into Puppet in detail, but it builds on top of our base Vagrant image to further set up our environment.
 
-Vagrant detects when you set up a new machine and runs Puppet or other Provisioners by default only once, although it also can be used to keep machines up to date, which is a bit harder. See the ``Vagrantfile and`` `Vagrant Documentation <https://www.vagrantup.com/docs>`_, especially the ``Provisioning`` chapter.
+Vagrant detects when you set up a new machine and runs Puppet or other Provisioners by default only once, although it also can be used to keep machines up to date, which is a bit harder. See the :file:`Vagrantfile` and `Vagrant Documentation <https://www.vagrantup.com/docs>`_, especially the *Provisioning* chapter.
 
 This is basically what Puppet does if we were to configure our system by hand:
 

--- a/theming/adv-resource-registry.rst
+++ b/theming/adv-resource-registry.rst
@@ -3,25 +3,25 @@ Advanced resources registry usage
 =================================
 
 In the Plone *resource registry* we can register our static resources, like
-CSS and LESS files and also JavaScript resources.
-We will cover here only CSS and LESS, but you can also do nice things
+CSS and Less files and also JavaScript resources.
+We will cover here only CSS and Less, but you can also do nice things
 with your JavaScript resources (for example using *requirejs* to do the import
 correctly without worrying about import order).
 For details about this, look into the documentation of the *resource registry*
 and in the JavaScript part of the training.
 
 
-Registering CSS/LESS resources in the registry
+Registering CSS/Less resources in the registry
 ==============================================
 
-Because of the flexibility of LESS over CSS we will use only LESS files here,
-but static CSS files can be registered in the same way. LESS files have the
+Because of the flexibility of Less over CSS we will use only Less files here,
+but static CSS files can be registered in the same way. Less files have the
 advantage that we can use imports, and with ``reference-imports`` we can even
 import only the parts of the files which we are really using.
 
 Let's see how we can register a resource in the resource registry.
-To do that, we add an ``IResourceRegistry`` entry into the ``registry.xml`` in
-our ``profiles/default`` folder:
+To do that, we add an ``IResourceRegistry`` entry into the :file:`registry.xml` in
+our :file:`profiles/default` folder:
 
 .. code-block:: xml
 
@@ -35,8 +35,8 @@ our ``profiles/default`` folder:
        </records>
    </registry>
 
-This registers a file named ``main.less`` (from our theme package named
-``plonetheme.tango``) as a *resource* named ``tango-main``.
+This registers a file named :file:`main.less` (from our theme package named
+:file:`plonetheme.tango`) as a *resource* named ``tango-main``.
 We can now add this resource to a *resource bundle* like the existing ``plone`` bundle:
 
 .. code-block:: xml
@@ -61,7 +61,7 @@ We can now add this resource to a *resource bundle* like the existing ``plone`` 
 This has the advantage of reducing the number of bundles,
 which also means reducing the amount of files which are loaded for the site,
 because every bundle will result in *one* compiled CSS file and *one* compiled JavaScript file.
-So if we have multiple LESS resources in the same bundle, they will be merged into one compiled
+So if we have multiple Less resources in the same bundle, they will be merged into one compiled
 CSS file.
 
 We can also create our own custom bundle which contains our resource (this is the way we
@@ -116,14 +116,14 @@ If you have created your own bundle, do the same for this bundle:
 Default value for ``site-id`` is ``Plone`` so you only need to specify that if you're working with a different id for your site object.
 
 
-Using resources in LESS-files
+Using resources in Less-files
 =============================
 
-Let's have a look at our ``main.less`` file:
+Let's have a look at our :file:`main.less` file:
 
 .. code-block:: sass
 
-   /* bundle LESS file that will be compiled into tango-compiled.css */
+   /* bundle Less file that will be compiled into tango-compiled.css */
 
    // ### PLONE IMPORTS ###
 
@@ -211,17 +211,17 @@ Let's have a look at our ``main.less`` file:
    // include our custom less
    @import "custom.less";
 
-Here we use different functionality of LESS and the resource registry.
+Here we use different functionality of Less and the resource registry.
 
-At the bottom line for example, we use LESS-imports to import a second LESS file
-which contains our custom LESS statements.
-And we also import a CSS-file of the downloaded theme as a LESS-file, so we can
-change parts of it using LESS-syntax.
+At the bottom line for example, we use Less-imports to import a second Less file
+which contains our custom Less statements.
+And we also import a CSS-file of the downloaded theme as a Less-file, so we can
+change parts of it using Less-syntax.
 
 Besides these two, we import stuff from Barceloneta. Here we can see that we use
 the names of the registered resource registry resources of the Barceloneta theme
 to import them. So if for example we want to import our registered resource
-``tango-main``, we could import it as follows in our LESS-file:
+``tango-main``, we could import it as follows in our Less-file:
 
 .. code-block:: css
 
@@ -233,7 +233,7 @@ or even with the ``reference`` option:
 
    @import (reference) "@{tango-main}";
 
-If you use the ``reference`` option on LESS-import, only the parts of this file
+If you use the ``reference`` option on Less-import, only the parts of this file
 which are used are included in the compiled version (CSS).
 
 So for example you have to trigger it like:

--- a/theming/basic.rst
+++ b/theming/basic.rst
@@ -17,26 +17,26 @@ Topics covered:
 Customize logo
 --------------
 
-1. go to plone control panel: toolbar -> admin -> Site Setup
-2. go to "Site" control panel
-3. you will see this form
+1. Go to the Plone Control Panel: toolbar -> admin -> Site Setup
+2. Go to the "Site" control panel.
+3. You will see this form:
 
-.. image:: http://docs.plone.org/_images/change-logo-in-site-control-panel.png
+   .. image:: http://docs.plone.org/_images/change-logo-in-site-control-panel.png
 
 4. You can now add / remove your custom logo
 
-See `official docs <http://docs.plone.org/adapt-and-extend/change-the-logo.html>`_.
+See the `official docs <http://docs.plone.org/adapt-and-extend/change-the-logo.html>`_.
 
 
 Customize CSS/LESS variables
 ----------------------------
 
-1. go back to control panel
-2. got to "Resource Registries" control panel
-3. on the first tab: enable "Development Mode"
-4. in the "plone" bundle below, click on "develop CSS".
+1. Go back to the Control Panel.
+2. Go to the "Resource Registries" control panel.
+3. On the first tab: enable "Development Mode".
+4. In the "plone" bundle below, click on "develop CSS".
 
-Your panel should now look like this
+Your panel should now look like this:
 
 .. image:: _static/theming-dev_mode_on.png
    :align: center
@@ -44,19 +44,21 @@ Your panel should now look like this
 
 Now we can play with some LESS variables:
 
-1. go to "Less Variables" tab
-2. find the var ``plone-left-toolbar-expanded`` and set it to 400px
+1. Go to the "Less Variables" tab.
+2. Find the variable ``plone-left-toolbar-expanded`` and set it to 400px.
 
 .. image:: _static/theming-less_var_hack.png
    :align: center
 
 
-3. hit save button upper right and reload the page
-4. click on the toolbar logo to expand the toolbar: voilá!
+3. Hit the :guilabel:`Save` button in the upper right and reload the page.
+4. Click on the toolbar logo to expand the toolbar: voilá!
 
-You can play around with some other var, if you want.
+You can play around with some other variables, if you want.
 
 ..  Warning::
 
-    "Development Mode" is really expensive for the browser, so depending on the browser and on the system you might encounter extreme slowness while rendering the page. You could see an unthemed page for a while.
+    "Development Mode" is really expensive for the browser.
+    Depending on the browser and on the system, you might encounter extreme slowness while rendering the page.
+    You could see an unthemed page for a while.
     Remember to switch it off as soon as you finished tweaking.

--- a/theming/collective-jbot.rst
+++ b/theming/collective-jbot.rst
@@ -29,5 +29,6 @@ TODO
 SCREENSHOTS
 
 Additional goodie
-----------------
+-----------------
+
 Overrides are stored on the filesystem and you can version / backup them as you like!

--- a/theming/creating-customizing-templates.rst
+++ b/theming/creating-customizing-templates.rst
@@ -15,18 +15,18 @@ the url ``./@@manage-viewlets``).
 To override them from your theme product, the easiest way is to use
 ``z3c.jbot`` (Just a Bunch of Templates).
 
-Since jbot is already included in the ``bobtemplates.plone`` theme skeleton,
+Since jbot is already included in the :py:mod:`bobtemplates.plone` theme skeleton,
 you can start using it immediately by adding all the templates you want to
-override in the ``src/plonetheme/tango/browser/overrides`` directory.
+override in the :file:`src/plonetheme/tango/browser/overrides` directory.
 
 In order for jbot to match the override to the template which is being
 overridden, the name of the *new* template needs to include the 
 complete path to the original template as a prefix (with every ``/`` replaced
 by ``.``).
 
-For instance, to override ``colophon.pt`` from ``plone.app.layout``, knowing
-that this template is found in a subfolder named ``viewlets``, you need to name
-the overriding template ``plone.app.layout.viewlets.colophon.pt``.
+For instance, to override :file:`colophon.pt` from :py:mod:`plone.app.layout`, knowing
+that this template is found in a subfolder named :file:`viewlets`, you need to name
+the overriding template :file:`plone.app.layout.viewlets.colophon.pt`.
 
 .. note:: ZMI > portal_view_customizations is a handy way to find the template path.
 
@@ -36,10 +36,10 @@ You can now restart Plone to see the effect.
 Overriding Event Item template
 ******************************
 
-The path to the original template is ``plone/app/event/browser/event_view.pt``,
+The path to the original template is :file:`plone/app/event/browser/event_view.pt`,
 so the full dotted name for our replacement template should be:
-``plone.app.event.browser.event_view.pt``.
-Create a new file with this dotted name into the ``overrides`` folder.
+:file:`plone.app.event.browser.event_view.pt`.
+Create a new file with this dotted name into the :file:`overrides` folder.
 
 Let's say we want to move the full text of the event item to appear before the
 event details block.
@@ -98,11 +98,11 @@ To render our dynamic content for the slider we need a custom view in Plone.
 There are various ways to create Views.
 For now, we will use a very simple template-only-view via jbot and
 ``theming-plugins``.
-The ``bobtemplates.plone`` skeleton includes everything you need.
+The :py:mod:`bobtemplates.plone` skeleton includes everything you need.
 
-The only thing we need to do, is to add a folder named ``views`` in our theme
+The only thing we need to do, is to add a folder named :file:`views` in our theme
 folder.
-Here we now create a template file named ``slider-images.pt``.
+Here we now create a template file named :file:`slider-images.pt`.
 
 .. code-block:: bash
 

--- a/theming/creating-initial-content-for-the-theme.rst
+++ b/theming/creating-initial-content-for-the-theme.rst
@@ -3,10 +3,10 @@ Creating initial content for the theme
 ======================================
 
 Our theme relies on some initial content structure,
-specifically the ``slider-images`` folder with some images inside.
+specifically the :file:`slider-images` folder with some images inside.
 Let's improve our theme package to create this content on install.
 
-To do that we create the ``slider-images`` folder in our ``setuphandlers.py``
+To do that we create the :file:`slider-images` folder in our :file:`setuphandlers.py`
 and load also some example images into that folder.
 
 .. code-block:: python

--- a/theming/theme-package.rst
+++ b/theming/theme-package.rst
@@ -5,7 +5,7 @@ Create a Plone theme python package
 Creating a theme product with the Diazo inline editor is an easy way to start
 and to test, but it is not a solid long term solution.
 
-Even if ``plone.app.theming`` allows importing and exporting of a Diazo theme
+Even if :py:mod:`plone.app.theming` allows importing and exporting of a Diazo theme
 as a ZIP archive, it might be preferable to manage your theme as an actual
 Plone product.
 
@@ -40,7 +40,7 @@ To create a Plone 5 theme skeleton, you will use mr.bob's templates for Plone.
 Install mr.bob and bobtemplates.plone
 -------------------------------------
 
-To install ``mr.bob``, you can use ``pip``:
+To install :py:mod:`mr.bob`, you can use :command:`pip`:
 
 .. code-block:: bash
 
@@ -52,7 +52,7 @@ and to install the required bobtemplates for Plone, do:
 
    $ pip install bobtemplates.plone
 
-Create a Plone 5 theme product skeleton with mrbob:
+Create a Plone 5 theme product skeleton with :command:`mrbob`:
 
 .. code-block:: bash
 
@@ -227,7 +227,7 @@ If you got a static mockup from your designer or from a website like
 http://startbootstrap.com (where the example theme came from), you can use this
 without customization and just apply the Diazo rules to it.
 Another way is to change the static mockup a little bit to use mostly the same
-CSS ids and classes. This way it is easier to reuse CSS/LESS from Barceloneta
+CSS ids and classes. This way it is easier to reuse CSS/Less from Barceloneta
 theme if you want.
 
 
@@ -355,7 +355,7 @@ Using Diazo rules to map the theme with Plone content
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Now that we have the static theme,
-we need to apply the Diazo rules in ``rules.xml`` to map the Plone content
+we need to apply the Diazo rules in :file:`rules.xml` to map the Plone content
 elements to the theme.
 
 First let me explain what we mean when we talk about *content* and *theme*.
@@ -790,7 +790,7 @@ CSS and JS resources
 
 First let's make sure that we have loaded the ``registerless`` profile of
 Barceloneta.
-To do that, we change our ``metadata.xml`` as follows:
+To do that, we change our :file:`metadata.xml` as follows:
 
 .. code:: xml
 
@@ -803,10 +803,10 @@ To do that, we change our ``metadata.xml`` as follows:
      </dependencies>
    </metadata>
 
-This will register all LESS files of the Barceloneta theme in Plone's resource
-registry, so that we can use them in our custom LESS files.
+This will register all Less files of the Barceloneta theme in Plone's resource
+registry, so that we can use them in our custom Less files.
 
-Now let's add the two LESS files ``main.less`` and ``custom.less`` to our CSS
+Now let's add the two Less files :file:`main.less` and :file:`custom.less` to our CSS
 folder:
 
 .. code-block:: bash
@@ -819,7 +819,7 @@ folder:
    ├── custom.less
    └── main.less
 
-The ``main.less`` file can look like this:
+The :file:`main.less` file can look like this:
 
 .. code-block:: sass
 
@@ -914,12 +914,12 @@ The ``main.less`` file can look like this:
 Here we import a number of specific parts from the default Plone 5 Barceloneta theme.
 Feel free to comment out stuff that you don't need.
 
-At the bottom you can see that we import the ``business-casual.css`` as a LESS
-file, as well as our new ``custom.less`` file.
-The ``business-casual.css`` comes from the downloaded static theme and is
+At the bottom you can see that we import the :file:`business-casual.css` as a Less
+file, as well as our new :file:`custom.less` file.
+The :file:`business-casual.css` comes from the downloaded static theme and is
 included to reduce the amount of CSS files.
 
-The ``custom.less`` will contain our custom styles and can look like this:
+The :file:`custom.less` will contain our custom styles and can look like this:
 
 .. code-block:: css
 
@@ -928,7 +928,7 @@ The ``custom.less`` will contain our custom styles and can look like this:
    }
 
 Before we register our bundle, let's also add a JavaScript file with the
-following content as ``js/bundle.js``:
+following content as :file:`js/bundle.js`:
 
 .. code-block:: js
 
@@ -960,12 +960,12 @@ following content as ``js/bundle.js``:
 
 We now have to register our resources in a bundle. We could use the new
 resource registry directly, but to make this training much simpler and
-easier to understand, we'll prefer to use the new options in ``manifest.cfg``.
+easier to understand, we'll prefer to use the new options in :file:`manifest.cfg`.
 Those allow us to register our CSS and JS in a pre-built implicit ``diazo``
 bundle that is only delivered when Diazo transformations are enabled (which
 is default) in ``@@theming-controlpanel``.
 
-So we extend our theme's ``manifest.cfg`` to declare ``development-css``,
+So we extend our theme's :file:`manifest.cfg` to declare ``development-css``,
 ``production-css`` and optionally ``tinymce-content-css``, like this:
 
 
@@ -1031,7 +1031,7 @@ And add these parts to the list of parts:
        zopepy
        omelette
 
-Also add ``Products.CMFPlone`` to the eggs list in the ``instance`` part:
+Also add :py:mod:`Products.CMFPlone` to the eggs list in the ``instance`` part:
 
 .. code-block:: ini
 
@@ -1052,7 +1052,7 @@ Now rerun buildout:
    $ ./bin/buildout
 
 This will generate some new scripts including ``plone-compile-resources`` and
-``plone-generate-gruntfile`` in the ``bin`` folder:
+:command:`plone-generate-gruntfile` in the :file:`bin` folder:
 
 .. code-block:: bash
 
@@ -1077,12 +1077,12 @@ This will generate some new scripts including ``plone-compile-resources`` and
    code-analysis-zptlint               zopepy
    develop
 
-You can use ``./bin/plone-compile-resources`` to build your resource bundle as
+You can use :command:`./bin/plone-compile-resources` to build your resource bundle as
 detailed below, but you first have to start the instance and add a Plone site
 named ``Plone``, because the compilation process depends on the resource
 registries of the live site.
 
-We also need ``grunt`` installed on our system.
+We also need :program:`grunt` installed on our system.
 
 .. code-block:: bash
 
@@ -1101,15 +1101,15 @@ then use this as a workaround and try again:
 
    npm config set registry http://registry.npmjs.org/
 
-.. note:: You have to rebuild the bundle whenever you make changes to your LESS/CSS files.
+.. note:: You have to rebuild the bundle whenever you make changes to your Less/CSS files.
 
-To test changes in LESS files you can build/rebuild your bundle TTW in Plone's
+To test changes in Less files you can build/rebuild your bundle TTW in Plone's
 ``resource registry`` control panel.
 Just go to ``@@resourceregistry-controlpanel`` and press *Build* for the tango-bundle.
 
 .. TODO:: show some screenshots here.
 
-Alternatively, you can use the ``plone-compile-resources`` script to rebuild the bundle.
+Alternatively, you can use the :command:`plone-compile-resources` script to rebuild the bundle.
 If you are running a ZEO cluster with multiple clients, you can run this script at any time.
 If not, you have to stop your instance first, because the script needs to write to the ZODB.
 
@@ -1121,10 +1121,10 @@ This will start the Plone instance, read variables from the registry, and
 compile your bundle.
 
 If your Plone site is not named ``Plone``, you can provide the id using the
-``--site-id`` parameter.
+:option:`--site-id` parameter.
 
-After you compiled your bundle with the ``plone-compile-resources`` once,
-you can use the generated ``Gruntfile.js`` and recompile your bundle as follows:
+After you compiled your bundle with the :command:`plone-compile-resources` once,
+you can use the generated :file:`Gruntfile.js` and recompile your bundle as follows:
 
 .. code-block:: bash
 
@@ -1132,17 +1132,17 @@ you can use the generated ``Gruntfile.js`` and recompile your bundle as follows:
 
 The name of our bundle is ``tango-bundle``. You can find the name of the
 generated *Grunt task* to compile your bundle at the bottom of the
-``Gruntfile.js``.
+:file:`Gruntfile.js`.
 
 .. note::
 
     This Grunt-only method is much faster than using the
-    ``plone-compile-resources`` script, but it cannot be used in all
+    :command:`plone-compile-resources` script, but it cannot be used in all
     circumstances.
 
    Specifically, you can use this direct method until you change something in
    the resources and bundle registration.  Then you have to use the
-   ``plone-compile-resources`` once again, before you can use the pure Grunt
+   :command:`plone-compile-resources` once again, before you can use the pure Grunt
    method.
 
 
@@ -1150,11 +1150,11 @@ generated *Grunt task* to compile your bundle at the bottom of the
 .. +++++++++++++++++++++++
 
 .. Since Plone already uses Bootstrap internally, we only need to load some parts of Bootstrap which does not come with Plone.
-.. To find out what parts of Bootstrap Plone uses already, you can look into ``Products/CMFPlone/profiles/dependencies/registry.xml`` or in the Resource Registry TTW.
-.. But I would recommend the ``registry.xml`` file because, it is easier to search in.
-.. So if you search for bootstrap in the ``registry.xml`` you will find out that Plone uses at least the follwing parts of Bootstrap already:
+.. To find out what parts of Bootstrap Plone uses already, you can look into :file:`Products/CMFPlone/profiles/dependencies/registry.xml` or in the Resource Registry TTW.
+.. But I would recommend the :file:`registry.xml` file because, it is easier to search in.
+.. So if you search for bootstrap in the :file:`registry.xml` you will find out that Plone uses at least the following parts of Bootstrap already:
 
-.. LESS files
+.. Less files
 .. **********
 
 .. * less/variables.less
@@ -1182,12 +1182,12 @@ generated *Grunt task* to compile your bundle at the bottom of the
 .. * js/transition.js
 
 
-Load LESS parts of Bootstrap
+Load Less parts of Bootstrap
 ****************************
 
-To load for example the carousel we first install the LESS version of Bootstrap
+To load for example the carousel we first install the Less version of Bootstrap
 into our theme.
-To do that, we use ``bower``, which you should have globally installed on your
+To do that, we use :program:`bower`, which you should have globally installed on your
 system.
 First we initialize our theme package. To do that, we run the following command
 inside our theme folder:
@@ -1197,9 +1197,9 @@ inside our theme folder:
    $ bower init
 
 This command will ask you some questions, which are all irrelevant for our purposes.  So we can accept all the default answers, except perhaps marking the package as private, as a precaution.  After this we have a bower config file called
-``bower.json``.
+:file:`bower.json`.
 All the packages that we need for our theme should be mentioned in this
-``bower.json`` file.
+:file:`bower.json` file.
 
 Now we install bootstrap, using bower:
 
@@ -1207,7 +1207,7 @@ Now we install bootstrap, using bower:
 
    $ bower install bootstrap --save
 
-The ``--save`` option will add the package to ``bower.json`` for us.
+The :option:`--save` option will add the package to :file:`bower.json` for us.
 Now, we can install all dependencies on any other system by running the
 following command from inside of our theme folder:
 
@@ -1216,7 +1216,7 @@ following command from inside of our theme folder:
    $ bower install
 
 Now that we have installed bootstrap using bower, we have all bootstrap
-components available in the subfolder called ``bower_components``:
+components available in the subfolder called :file:`bower_components`:
 
 .. code-block:: bash
 
@@ -1347,7 +1347,7 @@ components available in the subfolder called ``bower_components``:
    └── README.md
 
 To include the needed "carousel" part and some other bootstrap components which
-our downloaded theme uses, we change the end of our ``main.less`` like this:
+our downloaded theme uses, we change the end of our :file:`main.less` like this:
 
 .. code-block:: css
 
@@ -1378,12 +1378,12 @@ our downloaded theme uses, we change the end of our ``main.less`` like this:
 Final CSS customization
 +++++++++++++++++++++++
 
-To make our theme look nicer, we add some CSS as follows to our ``custom.less``
+To make our theme look nicer, we add some CSS as follows to our :file:`custom.less`
 file:
 
 .. code:: less
 
-   /* Custom LESS file that is included from the main.less file */
+   /* Custom Less file that is included from the main.less file */
 
    .brand-name{
        margin-top: 0.5em;

--- a/theming/tinymce-templates.rst
+++ b/theming/tinymce-templates.rst
@@ -11,8 +11,8 @@ The users then only need to customize this content to their needs.
 Create your own TinyMCE templates
 =================================
 
-We create a folder named ``tinymce_templates`` in our theme folder and put a
-file in named ``content-box.html`` in it:
+We create a folder named :file:`tinymce_templates` in our theme folder and put a
+file in named :file:`content-box.html` in it:
 
 .. code-block:: bash
 
@@ -21,7 +21,7 @@ file in named ``content-box.html`` in it:
    tinymce_templates/
    └── content-box.html
 
-In the file ``content-box.html`` we put this HTML template content:
+In the file :file:`content-box.html` we put this HTML template content:
 
 .. code-block:: html
 

--- a/theming/ttw-advanced.rst
+++ b/theming/ttw-advanced.rst
@@ -6,7 +6,7 @@ In this section you will:
 
 * Use the "Theming" control panel to make a copy of Plone's default theme (barceloneta)
 * Customize a theme using Diazo rules
-* Customize a theme by editing and compiling LESS files
+* Customize a theme by editing and compiling Less files
 
 Topics covered:
 
@@ -21,7 +21,7 @@ What is Diazo?
 --------------
 
 ``Diazo`` is a theming engine used by Plone to make theming a site easier.
-At it's core, a Diazo theme consists of an HTML page and rules.xml file containing directives.
+At its core, a Diazo theme consists of an HTML page and rules.xml file containing directives.
 
 .. note::
 
@@ -63,14 +63,14 @@ Anatomy of a Diazo theme
 
 The most important files:
 
-* ``manifest.cfg``: contains metadata about the theme (`manifest reference <http://docs.plone.org/external/plone.app.theming/docs/index.html#the-manifest-file>`_);
-* ``rules.xml``: contains the theme rules (`rules reference <http://docs.plone.org/external/plone.app.theming/docs/index.html#rules-syntax>`_);
-* ``index.html``: the static HTML of the theme.
+* :file:`manifest.cfg`: contains metadata about the theme (`manifest reference <http://docs.plone.org/external/plone.app.theming/docs/index.html#the-manifest-file>`_);
+* :file:`rules.xml`: contains the theme rules (`rules reference <http://docs.plone.org/external/plone.app.theming/docs/index.html#rules-syntax>`_);
+* :file:`index.html`: the static HTML of the theme.
 
 
 Custom rules
 ------------
-Let's open ``rules.xml``. You will see all the rules that are used in Barceloneta theme right now. For the time being let's concentrate on how to hack these rules.
+Let's open :file:`rules.xml`. You will see all the rules that are used in Barceloneta theme right now. For the time being let's concentrate on how to hack these rules.
 
 Conditionally showing content
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/theming/ttw-advanced_2.rst
+++ b/theming/ttw-advanced_2.rst
@@ -14,7 +14,7 @@ Instead of copying it, Barceloneta can inherited by a custom theme. Two elements
 
 Create a new theme in the theming editor containing the following files:
 
-- ``manifest.cfg``, declaring your theme:
+- :file:`manifest.cfg`, declaring your theme:
 
 .. code-block:: ini
 
@@ -24,7 +24,7 @@ Create a new theme in the theming editor containing the following files:
     development-css = /++theme++mytheme/styles.less
     production-css = /++theme++mytheme/styles.css
 
-- ``rules.xml``, including the Barceloneta rules:
+- :file:`rules.xml`, including the Barceloneta rules:
 
 .. code-block:: xml
 
@@ -44,9 +44,9 @@ Create a new theme in the theming editor containing the following files:
 
     </rules>
 
-- a copy of ``index.html`` from Barceloneta (this one cannot be imported or inherited, it must be local to your theme).
+- a copy of :file:`index.html` from Barceloneta (this one cannot be imported or inherited, it must be local to your theme).
 
-- ``styles.less``, importing Barceloneta styles:
+- :file:`styles.less`, importing Barceloneta styles:
 
 .. code-block:: css
 
@@ -60,7 +60,7 @@ Create a new theme in the theming editor containing the following files:
       color: @plone-text-color;
     }
 
-Then you have to compile ``styles.less`` to obtain your ``styles.css`` file using the "Build CSS" button.
+Then you have to compile :file:`styles.less` to obtain your :file:`styles.css` file using the "Build CSS" button.
 
 Your theme is ready.
 
@@ -107,7 +107,7 @@ Here is an example::
 
 Imagine you might want to use Barceloneta for the website administrators (so they can manage the content conviniently) and offer a completely different layout for visitors, you just need to create rules with ``css:if-content="body.userrole-anonymous"`` or ``css:if-content="body.:not(userrole-anonymous)"`` to enable the theme you want.
 
-As you can see, if the visitor is anonymous, Diazo will use a specific HTML theme (named ``front.html``) and not the Barceloneta's ``index.html``.
+As you can see, if the visitor is anonymous, Diazo will use a specific HTML theme (named :file:`front.html`) and not the Barceloneta's :file:`index.html`.
 
 Exercise: create a specific design for visitors only
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,10 +117,10 @@ Go to http://www.csszengarden.com/, download a theme (do not use the download li
 ..  admonition:: Solution
     :class: toggle
 
-    - create a ``front`` folder in the theme,
+    - create a :file:`front` folder in the theme,
     - put the 2 downloaded files in this folder,
-    - in ``index.html``, fix the ``<link>`` element to load ``front/style.css``,
-    - change ``rules.xml`` to:
+    - in :file:`index.html`, fix the ``<link>`` element to load :file:`front/style.css`,
+    - change :file:`rules.xml` to:
 
         .. code-block:: xml
 

--- a/ttw/mosaic.rst
+++ b/ttw/mosaic.rst
@@ -3,42 +3,46 @@ Mosaic
 
 In this part you will:
 
-* create a home page layout,
-* create a specific talk detail layout,
+* create a *home page* layout,
+* create a *specific talk detail* layout.
 
 Topics covered:
 
-* Create custom layouts
-* Manage layouts
-* Use the layout editor
+* Create custom layouts.
+* Manage layouts.
+* Use the layout editor.
 
 What is Mosaic?
 ---------------
 
 * A Plone add-on,
-* it allows to manage layouts from the Plone interface.
+* which allows managing layouts from the Plone interface.
 
-Few comparisons
----------------
+Some comparisons
+----------------
 
 .. only:: presentation
 
-    * It allows managing of the layout, not the design (like Diazo).
-    * It can manage the layout of any page, it does not provide a specific layout-enabled content (like collective.cover).
+    * It allows to manage the *layout*, not the *design* (unlike Diazo).
+    * It can manage the layout of *any* page, it does not provide a specific layout-enabled content type (like :py:mod:`collective.cover`).
 
 .. only:: not presentation
 
-    * Compare to Diazo:
+    * Compared to Diazo:
 
-        Diazo allows to theme our Plone site, by providing CSS, images, and HTML templates. And it will apply to the entire page (footer, main content, portlets, etc.).
+      Diazo enables theming our Plone site by providing CSS, images,
+      and HTML templates.
+      It will apply to the entire page (footer, main content, portlets, etc.).
 
-        Mosaic uses the grid provided by our design to dynamically build specific content layouts.
+      Mosaic uses the grid provided by our design to dynamically build specific
+      content layouts.
 
-    * Compare to collective.cover:
+    * Compared to :py:mod:`collective.cover`:
 
-        collective.cover provides a specific content-type (a "Cover page") where we can manage the layout in order to build our homepage.
+      :py:mod:`collective.cover` provides a specific content-type 
+      (a "Cover page") where we can manage the layout in order to build our homepage.
 
-        Mosaic does not provide any content-type, it allows to edit any existing content layout.
+      Mosaic does not provide any content-type, it allows to edit any existing content layout.
 
 Installation
 ------------
@@ -49,7 +53,7 @@ Once deployed, create a Plone site, and go to Plone control panel / Add-ons http
 
 .. only:: not presentation
 
-    Modify ``buildout.cfg`` to add Rapido as a dependency::
+    Modify :file:`buildout.cfg` to add Rapido as a dependency::
 
         eggs =
             ...
@@ -210,15 +214,15 @@ Manage custom layouts
 Custom layouts can be managed from the Plone control panel:
 
 - click on user menu / Site settings,
-- click on Mosaic Layout Editor (in the last section, named "Add-on configuration"),
+- click on Mosaic Layout Editor (in the last section, named :guilabel:`Add-on configuration`),
 
-In the third tab of this control panel, named "Show/hide content layouts", we can see the exitsing layouts, their associated content types, and we can deactivate (or re-activate) them by clicking on "Hide" (or "Show").
+In the third tab of this control panel, named "Show/hide content layouts", we can see the existing layouts, their associated content types, and we can deactivate (or re-activate) them by clicking on :guilabel:`Hide` (or :guilabel:`Show`).
 
-In the first tab, named "Content layouts", there is a source editor.
+In the first tab, named :guilabel:`Content layouts`, there is a source editor.
 
-By editing ``manifest.cfg``, we can assign a layout to another content type by changing the ``for =`` line. If we remove this line, the layout is available for any content type.
+By editing :file:`manifest.cfg`, we can assign a layout to another content type by changing the ``for =`` line. If we remove this line, the layout is available for any content type.
 
-We can also delete the layout section from ``manifest.cfg``, and the layout will be deleted (if we do so, it is recommended to delete its associated HTML file too).
+We can also delete the layout section from :file:`manifest.cfg`, and the layout will be deleted (if we do so, it is recommended to delete its associated HTML file too).
 
 Deleting a custom layout can also be managed in another way:
 
@@ -227,7 +231,7 @@ Note: the second tab, named "Site layouts", is not usable for now.
 
 Edit the layout HTML structure
 ------------------------------
-In the Mosaic Layout Editor's first tab ("Content layouts"), ``manifest.cfg`` is not the only editable file.
+In the Mosaic Layout Editor's first tab ("Content layouts"), :file:`manifest.cfg` is not the only editable file.
 
 There is also some HTML files. Each of them corresponds to a layout and they represent what we have built by drag&dropping tiles in our layouts.
 

--- a/ttw/rapido.rst
+++ b/ttw/rapido.rst
@@ -27,7 +27,7 @@ What is Rapido?
 
     Rapido is a Plone add-on that allows implementation of custom features on top of Plone.
     It is a simple yet powerful way to extend the behavior of your Plone site without using the underlying frameworks.
-    The **Plone theming tool** is the interface used to build ``rapido.plone`` applications.
+    The **Plone theming tool** is the interface used to build :py:mod:`rapido.plone` applications.
     This means that Rapido applications can be written both **on the file system** or using the **inline editor** of the Plone theming tool.
 
     A Rapido application is just a part of your current theme:
@@ -80,7 +80,7 @@ Installation
 
 .. only:: not presentation
 
-    Modify ``buildout.cfg`` to add Rapido as a dependency::
+    Modify :file:`buildout.cfg` to add Rapido as a dependency::
 
         eggs =
             ...
@@ -170,7 +170,7 @@ Blocks and elements
     * A block is defined by 3 files:
 
         - a YAML file to declare *elements*,
-        - an HTML (or ``.pt``) file for the layout,
+        - an HTML (or :file:`.pt`) file for the layout,
         - a Python file to implement the logic.
 
 .. only:: not presentation
@@ -441,8 +441,9 @@ we need to activate the AJAX mode in the YAML file:
 Exercise 4: Add the Like button
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Add a Like button to the block.
-For now, the action itself will do nothing, let's just insert it at the right place, and make sure the block is refreshed properly when we click.
+Add a *Like* button to the block.
+For now, the action itself will do nothing. 
+Let's just insert it at the right place, and make sure the block is refreshed properly when we click.
 
 .. admonition:: Solution
     :class: toggle
@@ -515,7 +516,7 @@ Exercise 5: Count votes
 The button is OK now, now let's focus on counting votes.
 To count the votes on a talk, you need store some information:
 
-- an identifier for the talk (we will take the talk path using the Plone ``absolute_url_path()`` method),
+- an identifier for the talk (we will use the talk path, from the Plone ``absolute_url_path()`` method),
 - the total votes it gets.
 
 Let's implement the ``like`` function:
@@ -541,7 +542,8 @@ Let's implement the ``like`` function:
 
 .. only:: not presentation
 
-    Note: we cannot just use the content ``id`` attribute as a valid identifier because it is not unique at site level, so we prefer the path.
+    Note: we cannot just use the content ``id`` attribute as a valid identifier
+    because it is not unique at site level, so we prefer the path.
 
 Now let's make sure to display the proper total in the ``display_votes`` element:
 
@@ -726,7 +728,7 @@ Let's create a block to display the Talks Top 5:
 
     And then we declare a new action in our footer:
 
-    - go to the `site_actions` in the Zope Management Interface::
+    - go to the ``site_actions`` in the Zope Management Interface::
 
         http://localhost:8080/Plone/portal_actions/site_actions/manage_workspace
 
@@ -769,7 +771,7 @@ The ``index_type`` property can have two possible values:
 
 Queries use the *CQE format* (`see documentation <http://docs.repoze.org/catalog/usage.html#query-objects>`_.
 
-Example (assuming `author`, `title` and `price` are existing indexes):
+Example (assuming ``author``, ``title`` and ``price`` are existing indexes):
 
 .. code-block:: python
 
@@ -826,9 +828,8 @@ We want to be able to sort the records according to their votes:
             record = context.app.get_record(content_path)
             if not record:
                 record = context.app.create_record(id=content_path)
-            total = record.get('total', 0)
-            total += 1
-            record['total'] = total
+                record['total'] = 0
+            record['total'] += 1
             record.save(block_id='rate')
 
 
@@ -881,7 +882,7 @@ Create custom content-rules
 
 Plone content rules allow triggering a given action depending on an *event*
 (content modified, content created, etc.)
-and on a *list of criteria* (only for certain content types,
+and on a *list of criteria* (for example: only for certain content types,
 only in this folder, etc.).
 
 Plone provides a set of useful ready-to-use content rule actions,
@@ -889,9 +890,8 @@ such as moving some content somewhere,
 sending mail to an email address,
 executing a workflow change, etc.
 
-Rapido allows to implement our own actions easily.
-
-Rapido just adds a generic "Rapido action" to the Plone content rules system.
+Rapido allows us to easily implement our own actions.
+To do this, it adds a generic "Rapido action" to the Plone content rules system.
 It allows us to enter the following parameters:
 
 - the app id,


### PR DESCRIPTION
This works toward making the docs more explicit and more amenable to
precise and consistent formatting.

I also fixed some typos, added some punctuation, capitalised some
acronyms, etc.

In some cases I left ``literal`` markup, where I couldn't decide what
kind of thing we were looking at. E.g. is a YAML "file" in a Rapido
app a file if it only lives in the ZODB? (I think it probably is.)

For changing Python "distribution" to "package", see
https://packaging.python.org/glossary/#term-distribution-package