### PR TITLE
Refactor: Naming of files in index

### DIFF
--- a/ttw/index.rst
+++ b/ttw/index.rst
@@ -11,10 +11,10 @@
    :maxdepth: 3
    :numbered: 1
 
-   basic
-   configuring_customizing
-   ttw-advanced
-   ttw-advanced_2
-   dexterity
+   Customizing logo and CSS of default theme <basic>
+   Configuring and Customizing Plone <configuring_customizing>
+   Introduction to Diazo Theming <ttw-advanced>
+   Creating a custom theme based on Barceloneta <ttw-advanced_2>
+   Dexterity <dexterity>
    mosaic
    rapido


### PR DESCRIPTION
This adjust the naming, of the files in the index.rst of ttw.

Note: there is nothing changed in the files which are included, its is just a toctree setting.

Before:

![ttw-1](https://cloud.githubusercontent.com/assets/358860/19213698/2abcf22e-8d73-11e6-9d31-fe12d7b4bb1e.png)

After:
![ttw-2](https://cloud.githubusercontent.com/assets/358860/19213700/35e5fd9e-8d73-11e6-8cbe-64e8de269232.png)

The user is already in the chapter 'ttw' we do not have to tell that in every header on the left :)

It also looks smoother on the eye :)