### PR TITLE
Update virtualenv create command in instrauctions as there are cases where it doesn't work

### DIFF
--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -53,7 +53,7 @@ Set up Plone for the training like this if you use your own OS (Linux or Mac):
     $ cd training
     $ git clone https://github.com/collective/training_buildout.git buildout
     $ cd buildout
-    $ virtualenv-2.7 py27
+    $ virtualenv-2.7 py27 or virtualenv --python=python2.7 py27
 
 Now you can run the buildout for the first time:
 


### PR DESCRIPTION
When I tried to create virtualenv with this command it doesn't work. The later one `virtualenv --python=python2.7 py27` worked for me.