### PR TITLE
Specify Python version for virtualenv using option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,6 +73,10 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 - Fix reST lists [davisagli]
 
+- Specify Python version for virtualenv using option, not command alias, as
+  alias is not always present [jean]
+
+
 1.2.4 (2014-10-03)
 ------------------
 

--- a/mastering_plone/about_mastering.rst
+++ b/mastering_plone/about_mastering.rst
@@ -172,7 +172,7 @@ To build the documentation follow these steps:
 
     $ git clone https://github.com/plone/training.git --recursive
     $ cd training
-    $ virtualenv-2.7 .
+    $ virtualenv --python=python2.7 .
     $ source bin/activate
 
 Now install dependencies and build.
@@ -191,7 +191,7 @@ Build new
 
     $ git clone https://github.com/plone/training.git --recursive
     $ cd training
-    $ virtualenv-2.7 .
+    $ virtualenv --python=python2.7 .
     $ source bin/activate
     $ pip install -r requirements.txt
     $ make html

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -53,7 +53,7 @@ Set up Plone for the training like this if you use your own OS (Linux or Mac):
     $ cd training
     $ git clone https://github.com/collective/training_buildout.git buildout
     $ cd buildout
-    $ virtualenv-2.7 py27 or virtualenv --python=python2.7 py27
+    $ virtualenv --python=python2.7 py27
 
 Now you can run the buildout for the first time:
 


### PR DESCRIPTION
Specify Python version for virtualenv using option, not command alias,
as alias is not always present.

See https://community.plone.org/t/typo-in-online-plone-4-training-plone-org/2914