### PR TITLE
Remove notes on features.rst that are no longer valid.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ This changelog is only very rough. For the full changelog please refer to https:
 1.2.5 (unreleased)
 ------------------
 - Update Features training to reflect that Dexterity is now supported by Working Copy Support and Placeful Workflow.
+
 - Fix a typo
   [staeff]
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 1.2.5 (unreleased)
 ------------------
-
+- Update Features training to reflect that Dexterity is now supported by Working Copy Support and Placeful Workflow.
 - Fix a typo
   [staeff]
 

--- a/mastering_plone/features.rst
+++ b/mastering_plone/features.rst
@@ -422,11 +422,6 @@ While it's shipped with Plone, working copy support is not a common need.
 So, if you need it, you need to activate it via the add-on packages configuration page.
 Unless activated, check-in/check-out options are not visible.
 
-.. Note::
-
-    Working-copy support is not yet available for content types created via Dexterity.
-    This is on the way.
-
 
 .. _features-placeful-wf-label:
 
@@ -444,7 +439,3 @@ Since it has effect in a "place" in a site, this mechanism is often called "Plac
 As with working-copy support, Placeful Workflow ships with Plone but needs to be activated via the add-on configuration page.
 Once it's added, a :guilabel:`Policy` option will appear on the state menu to allow setting a placeful workflow policy.
 
-.. Note::
-
-    Workflow Policy support is not yet available for folderish contenttypes created via Dexterity.
-    This is on the way.


### PR DESCRIPTION
Dexterity is now supported for Working Copy Support and Placeful Workflow.