### PR TITLE
Add note on known limitations concerning Dexterity / Working Copy Support.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ This changelog is only very rough. For the full changelog please refer to https:
 1.2.5 (unreleased)
 ------------------
 - Update Features training to reflect that Dexterity is now supported by Working Copy Support and Placeful Workflow.
+
 - Fix a typo
   [staeff]
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ This changelog is only very rough. For the full changelog please refer to https:
 1.2.5 (unreleased)
 ------------------
 - Update Features training to reflect that Dexterity is now supported by Working Copy Support and Placeful Workflow.
+  [robinsjm2]
 
 - Fix a typo
   [staeff]
@@ -13,7 +14,7 @@ This changelog is only very rough. For the full changelog please refer to https:
 - Fix typos, improve wording
   [svx]
 
-- Clarify which template we're editing 
+- Clarify which template we're editing
   [djowett]
 
 - Fix typos

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 1.2.5 (unreleased)
 ------------------
-
+- Update Features training to reflect that Dexterity is now supported by Working Copy Support and Placeful Workflow.
 - Fix a typo
   [staeff]
 

--- a/mastering_plone/features.rst
+++ b/mastering_plone/features.rst
@@ -422,7 +422,7 @@ While it's shipped with Plone, working copy support is not a common need.
 So, if you need it, you need to activate it via the add-on packages configuration page.
 Unless activated, check-in/check-out options are not visible.
 
-.. note::
+.. Note::
 
     Working Copy Support has limited support for Dexterity content types. The limitation is that there are some outstanding issues with folderish items that contain many items.
 

--- a/mastering_plone/features.rst
+++ b/mastering_plone/features.rst
@@ -422,6 +422,9 @@ While it's shipped with Plone, working copy support is not a common need.
 So, if you need it, you need to activate it via the add-on packages configuration page.
 Unless activated, check-in/check-out options are not visible.
 
+.. note::
+
+    Working Copy Support has limited support for Dexterity content types. The limitation is that there are some outstanding issues with folderish items that contain many items.
 
 .. _features-placeful-wf-label:
 

--- a/mastering_plone/features.rst
+++ b/mastering_plone/features.rst
@@ -422,11 +422,6 @@ While it's shipped with Plone, working copy support is not a common need.
 So, if you need it, you need to activate it via the add-on packages configuration page.
 Unless activated, check-in/check-out options are not visible.
 
-.. Note::
-
-    Working-copy support is not yet available for content types created via Dexterity.
-    This is on the way.
-
 
 .. _features-placeful-wf-label:
 
@@ -444,7 +439,3 @@ Since it has effect in a "place" in a site, this mechanism is often called "Plac
 As with working-copy support, Placeful Workflow ships with Plone but needs to be activated via the add-on configuration page.
 Once it's added, a :guilabel:`Policy` option will appear on the state menu to allow setting a placeful workflow policy.
 
-.. Note::
-
-    Workflow Policy support is not yet available for folderish contenttypes created via Dexterity.
-    This is on the way.


### PR DESCRIPTION
After removing the note that mentioned Working Copy Support does not work with content types created via Dexterity, there was some discussion that brought to light the known limitations by name.  This updated note does claim support but also refers directly to the known limitations, providing better information for the reader to choose how best to use the feature.