### PR TITLE
Use correct links for ZCA itself and usage in Pyramid

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 1.2.5 (unreleased)
 ------------------
+- Use correct links for ZCA itself and its usage in Pyramid, as well in
+  translation files.
+  [stevepiercy]
+
 - Update Features training to reflect that Dexterity is now supported by Working Copy Support and Placeful Workflow.
 
 - Fix a typo

--- a/_locales/anatomy.pot
+++ b/_locales/anatomy.pot
@@ -177,7 +177,7 @@ msgid "Zope Component Architecture (ZCA)"
 msgstr ""
 
 #: ../anatomy.rst:86
-# d3b14c1374024d0b9cb3b299dad0914e
+# d3b14c1374024d0b9cb3qb299dad0914e
 msgid "The `Zope Component Architecture <https://zopecomponent.readthedocs.io/en/latest/>`_ is a system which allows for application pluggability and complex dispatching based on objects which implement an interface. Pyramid uses the ZCA “under the hood” to perform view dispatching and other application configuration tasks."
 msgstr ""
 

--- a/_locales/anatomy.pot
+++ b/_locales/anatomy.pot
@@ -178,7 +178,7 @@ msgstr ""
 
 #: ../anatomy.rst:86
 # d3b14c1374024d0b9cb3b299dad0914e
-msgid "The `Zope Component Architecture <http://muthukadan.net/docs/zca.html>`_ is a system which allows for application pluggability and complex dispatching based on objects which implement an interface. Pyramid uses the ZCA “under the hood” to perform view dispatching and other application configuration tasks."
+msgid "The `Zope Component Architecture <https://zopecomponent.readthedocs.io/en/latest/>`_ is a system which allows for application pluggability and complex dispatching based on objects which implement an interface. Pyramid uses the ZCA “under the hood” to perform view dispatching and other application configuration tasks."
 msgstr ""
 
 #: ../anatomy.rst:90
@@ -193,7 +193,7 @@ msgstr ""
 
 #: ../anatomy.rst:93
 # e582e67056f14b83b5b193ff2bc9c942
-msgid "It does less than Zope, is very pluggable and `uses the Zope Component Architecture <https://docs.zope.org/zope.component/narr.html>`_."
+msgid "It does less than Zope, is very pluggable and `uses the Zope Component Architecture <https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/zca.html>`_."
 msgstr ""
 
 #: ../anatomy.rst:97

--- a/_locales/es/LC_MESSAGES/anatomy.po
+++ b/_locales/es/LC_MESSAGES/anatomy.po
@@ -246,12 +246,12 @@ msgstr "Zope Component Architecture (ZCA)"
 # d3b14c1374024d0b9cb3b299dad0914e
 #: ../anatomy.rst:86
 msgid ""
-"The `Zope Component Architecture <http://muthukadan.net/docs/zca.html>`_ is "
+"The `Zope Component Architecture <https://zopecomponent.readthedocs.io/en/latest/>`_ is "
 "a system which allows for application pluggability and complex dispatching "
 "based on objects which implement an interface. Pyramid uses the ZCA “under "
 "the hood” to perform view dispatching and other application configuration "
 "tasks."
-msgstr "La `Zope Component Architecture <http://muthukadan.net/docs/zca.html>`_ es un sistema el cual permite por la versatibilidad y despacho de aplicaciones basadas en objetos que implementan una interfaz. Pyramid usa la ZCA \"bajo la capucha\" para ejecutar despacho de vistas y otras tareas de configuración de aplicaciones."
+msgstr "La `Zope Component Architecture <https://zopecomponent.readthedocs.io/en/latest/>`_ es un sistema el cual permite por la versatibilidad y despacho de aplicaciones basadas en objetos que implementan una interfaz. Pyramid usa la ZCA \"bajo la capucha\" para ejecutar despacho de vistas y otras tareas de configuración de aplicaciones."
 
 # 6d8583e2c5384094822ef9b2847d74dc
 #: ../anatomy.rst:90
@@ -271,8 +271,8 @@ msgstr "`Pyramid <https://trypyramid.com>`_ es un framework de desarrollo de apl
 msgid ""
 "It does less than Zope, is very pluggable and `uses the Zope Component "
 "Architecture "
-"<https://docs.zope.org/zope.component/narr.html>`_."
-msgstr "Eso hace menos que Zope, es muy configurable y `usa la Arquitectura de Componentes Zope <https://docs.zope.org/zope.component/narr.html>`_."
+"<https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/zca.html>`_."
+msgstr "Eso hace menos que Zope, es muy configurable y `usa la Arquitectura de Componentes Zope <https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/zca.html>`_."
 
 # e13307aabc0e4534a17a8666d74ff28e
 #: ../anatomy.rst:97

--- a/mastering_plone/anatomy.rst
+++ b/mastering_plone/anatomy.rst
@@ -112,7 +112,7 @@ Zope Toolkit / Zope3
 Zope Component Architecture (ZCA)
 ---------------------------------
 
-The `Zope Component Architecture <http://muthukadan.net/docs/zca.html>`_, which was developed as part of Zope 3, is a system which allows for component pluggability and complex dispatching based on objects which implement an interface (a description of a functionality). It is a subset of the ZTK but can be used standalone. Plone makes extensive use of the ZCA in its codebase.
+The `Zope Component Architecture <https://zopecomponent.readthedocs.io/en/latest/>`_, which was developed as part of Zope 3, is a system which allows for component pluggability and complex dispatching based on objects which implement an interface (a description of a functionality). It is a subset of the ZTK but can be used standalone. Plone makes extensive use of the ZCA in its codebase.
 
 
 .. _anatomy-pyramid-label:


### PR DESCRIPTION
In #266 links to ZCA were updated, but since then I realized two things.

1. The canonical URL for docs is https://zopecomponent.readthedocs.io/en/latest/ per https://github.com/zopefoundation/zope.component/pull/25
2. Under the section about Pyramid, the context was for how Pyramid uses ZCA, not for ZCA itself, and should in fact point to Pyramid docs at https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/zca.html

This PR corrects the URLs and makes them consistent across the translation files as well.