### PR TITLE
Git rid of "duplicate label" warnings; add some markup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 1.2.5 (unreleased)
 ------------------
+- Fix some IDs and filename references [jean]
+
 - Use correct links for ZCA itself and its usage in Pyramid, as well in
   translation files.
   [stevepiercy]

--- a/deployment/index.rst
+++ b/deployment/index.rst
@@ -39,6 +39,7 @@ Automating Plone Deployment
     :hidden:
     :maxdepth: 3
     :caption: Plone Trainings
+    :name: plone-trainings-deployment-toc
 
     about/index
     about/glossary

--- a/javascript/index.rst
+++ b/javascript/index.rst
@@ -50,6 +50,7 @@ This training is **not** about:
    :hidden:
    :maxdepth: 3
    :caption: Plone Trainings
+    :name: plone-trainings-javascript-toc
 
    about/index
    about/glossary

--- a/solr/index.rst
+++ b/solr/index.rst
@@ -28,6 +28,7 @@ It powers the search of sites like Twitter, the Apple and iTunes Stores, Wikiped
 .. toctree::
    :maxdepth: 3
    :caption: Plone Trainings
+    :name: plone-trainings-solr-toc
    :hidden:
 
    about/index

--- a/theming/index.rst
+++ b/theming/index.rst
@@ -26,9 +26,10 @@ Plone Theming
    :hidden:
    :maxdepth: 3
    :caption: Plone Trainings
+   :name: plone-trainings-theming-toc
 
-    about/index
-    about/glossary
+   about/index
+   about/glossary
 
 .. seealso::
 

--- a/ttw/configuring-customizing.rst
+++ b/ttw/configuring-customizing.rst
@@ -8,7 +8,7 @@ Configuring And Customizing
 
  .. sectionauthor:: Philip Bauer <bauer@starzel.de>
 
-.. _customizing-controlpanel-label:
+.. _customizing-controlpanel-label-ttw:
 
 The Control Panel
 =================
@@ -86,7 +86,7 @@ Let's change the logo.
    https://docs.plone.org/adapt-and-extend/change-the-logo.html
 
 
-.. _customizing-portlets-label:
+.. _customizing-portlets-label-ttw:
 
 Portlets
 --------
@@ -116,7 +116,7 @@ Example:
   * You could turn that into a link to a copyright page later.
 
 
-.. _customizing-viewlets-label:
+.. _customizing-viewlets-label-ttw:
 
 Viewlets
 --------

--- a/ttw/dexterity.rst
+++ b/ttw/dexterity.rst
@@ -1,4 +1,4 @@
-.. _dexterity1-label:
+.. _dexterity1-label-ttw:
 
 =========
 Dexterity
@@ -17,7 +17,7 @@ Topics covered:
 * Widgets
 
 
-.. _dexterity1-what-label:
+.. _dexterity1-what-label-ttw:
 
 What Is A Content Type?
 =======================
@@ -38,7 +38,7 @@ Also, we'll want to be able to display talks featuring that special information,
 
 A custom content type will be ideal.
 
-.. _dexterity1-contains-label:
+.. _dexterity1-contains-label-ttw:
 
 The Makings Of A Plone Content Type
 ===================================
@@ -109,7 +109,7 @@ Views:
 * Display Forms.
 
 
-.. _dexterity1-modify-label:
+.. _dexterity1-modify-label-ttw:
 
 Modifying Existing Types
 ========================
@@ -134,7 +134,7 @@ Modifying Existing Types
 
    https://docs.plone.org/external/plone.app.contenttypes/docs/README.html#extending-the-types
 
-.. _dexterity1-create-ttw-label:
+.. _dexterity1-create-ttw-label-ttw:
 
 Creating Content Types "Through-The-Web"
 ========================================
@@ -219,7 +219,7 @@ Here is the complete XML schema created by our actions:
   </model>
 
 
-.. _dexterity1-ttw-to-code-label:
+.. _dexterity1-ttw-to-code-label-ttw:
 
 Moving Content Types Into Code
 ==============================
@@ -236,7 +236,7 @@ So, we'll ultimately want to move our new content type into a Python package. We
    * `The standard behaviors <https://docs.plone.org/external/plone.app.dexterity/docs/reference/standard-behaviours.html>`_
 
 
-.. _dexterity1-excercises-label:
+.. _dexterity1-excercises-label-ttw:
 
 Exercises
 =========

--- a/ttw/index.rst
+++ b/ttw/index.rst
@@ -29,6 +29,7 @@
    :hidden:
    :maxdepth: 3
    :caption: Plone Trainings
+    :name: plone-trainings-ttw-toc
 
    about/index
    about/glossary

--- a/ttw/ttw-advanced-2.rst
+++ b/ttw/ttw-advanced-2.rst
@@ -53,7 +53,6 @@ In this exercise we will create a new theme that inherits the Barceloneta rules 
 
    .. image:: _static/theming-new-theme.png
 
-
    and name it "Custom"
 
    .. image:: _static/theming-new-theme2.png
@@ -108,7 +107,7 @@ In this exercise we will create a new theme that inherits the Barceloneta rules 
       color: @plone-text-color;
     }
 
-Then generate the :file:`styles.css` file using :file:`styles.less` and the "Build CSS" button.
+Then generate the :file:`styles.css` file using :file:`styles.less` and the :guilabel:`Build CSS` button.
 
 Your theme is ready.
 
@@ -332,15 +331,16 @@ The theme is already packaged in a manner that will work with the theming tool.
 
 
 4. Add rules to include the Barceloneta backend utilities
-   ::
 
-       <?xml version="1.0" encoding="UTF-8"?>
-    <rules
-        xmlns="http://namespaces.plone.org/diazo"
-        xmlns:css="http://namespaces.plone.org/diazo/css"
-        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-        xmlns:xi="http://www.w3.org/2001/XInclude">
+   .. code-block:: xml
 
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rules
+          xmlns="http://namespaces.plone.org/diazo"
+          xmlns:css="http://namespaces.plone.org/diazo/css"
+          xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          xmlns:xi="http://www.w3.org/2001/XInclude">
+    
       <!-- Include the backend theme -->
       <xi:include href="++theme++barceloneta/backend.xml" />
 

--- a/ttw/ttw-advanced.rst
+++ b/ttw/ttw-advanced.rst
@@ -4,13 +4,13 @@ Introduction To Diazo Theming
 
 In this section you will:
 
-* Use the "Theming" control panel to make a copy of Plone's default theme (barceloneta)
+* Use the :guilabel:`Theming` control panel to make a copy of Plone's default theme (barceloneta)
 * Customize a theme using Diazo rules
 * Customize a theme by editing and compiling Less files
 
 Topics covered:
 
-* Diazo and plone.app.theming
+* Diazo and :py:mod:`plone.app.theming`
 * "Barceloneta" - The Default Plone Theme
 * The "Theming tool"
 * Building CSS in the "Theming tool"
@@ -112,7 +112,7 @@ What do you think is the purpose of the ``prefix`` property?
     in the location defined by the ``production-css`` property.
 
     The ``prefix`` property defines the default location to look for non prefixed files, for example
-    if your prefix is set to ``/++theme++mytheme`` then a file like index.html will be expected at
+    if your prefix is set to ``/++theme++mytheme`` then a file like :file:`index.html` will be expected at
     ``/++theme++mytheme/index.html``
 
 
@@ -147,7 +147,7 @@ Below you can see an example of the body classes for a page named "front-page", 
                  viewpermission-view
                  userrole-anonymous">
 
-``<body>`` Classes for A Manager
+``<body>`` Classes For A Manager
 --------------------------------
 
 And here is what the classes for the same page look like when viewed by a manager that has logged in:

--- a/workflow/index.rst
+++ b/workflow/index.rst
@@ -54,6 +54,7 @@ the ``portal_workflow`` screen in the ZMI when you change your workflows’ secu
    :hidden:
    :maxdepth: 3
    :caption: Plone Trainings
+   :name: plone-trainings-workflow-toc
 
    about/index
    about/glossary


### PR DESCRIPTION
Uniquify IDs that are computed from toctree caption.
Inconsistent indentation caused some spaces to be included in filenames.