### PR TITLE
fix restapi example - valid JSON in POST Body

### DIFF
--- a/mastering-plone/restapi.rst
+++ b/mastering-plone/restapi.rst
@@ -54,8 +54,8 @@ Plone will provide responses in JSON format. Some requests you could try:
     Content-Type: application/json
 
     {
-        'login': 'admin',
-        'password': 'admin',
+        "login": "admin",
+        "password": "admin"
     }
 
 Exercise
@@ -80,8 +80,8 @@ Add a new talk in Plone and then update it's title to match 'Foo 42' using the R
        Content-Type: application/json
 
        {
-           'login': 'admin',
-           'password': 'admin',
+           "login": "admin",
+           "password": "admin"
        }
 
     The response will look like this:


### PR DESCRIPTION
In the example the body of the POST won't work in postman as cut-and-pasted because it's not valid JSON.   The reply is
 {
    "message": "'No JSON object could be decoded'",
    "type": "DeserializationError"
}