### PR TITLE
Upgrade Vagrant setup to Ubuntu 18.04 LTS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -175,6 +175,9 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 - Add support for translations on transifex
   [macagua]
+  
+- Upgrade Vagrant setup to Ubuntu 18.04 LTS
+  [tschorr]
 
 
 1.2.3 (2014-07-11)

--- a/plone_training_config/Vagrantfile
+++ b/plone_training_config/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
 
   config.vm.hostname = "training.plone.org"
   config.vm.network :forwarded_port, guest: 8080, host: 8080
@@ -16,6 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize  ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     vb.customize  ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize  ["modifyvm", :id, "--natdnsproxy1", "on"]
+    vb.memory = "1536"
   end
 
   # A workaround for missing symbolic links on windows:

--- a/plone_training_config/instructions.rst
+++ b/plone_training_config/instructions.rst
@@ -156,7 +156,7 @@ You can stop the running instance anytime using :kbd:`ctrl + c`.
 Installing Plone with Vagrant
 -----------------------------
 
-We use a virtual machine (Ubuntu 16.04) to run Plone during the training.
+We use a virtual machine (Ubuntu 18.04) to run Plone during the training.
 
 We rely on `Vagrant <https://www.vagrantup.com>`_ and `VirtualBox <https://www.virtualbox.org>`_ to give the same development environment to everyone.
 
@@ -221,7 +221,7 @@ Now start setting up the virtual machine (VM) that is configured in :file:`Vagra
 
 This takes a **veeeeery loooong time** (between 10 minutes and 1h depending on your Internet connection and system speed) since it does all the following steps:
 
-* downloads a virtual machine (Official Ubuntu Server 16.04 LTS, also called "Xenial Xerus")
+* downloads a virtual machine (Official Ubuntu Server 18.04 LTS, also called "Bionic Beaver")
 * sets up the VM
 * updates the VM
 * installs various system-packages needed for Plone development
@@ -281,7 +281,7 @@ It is in :file:`/vagrant/buildout/`. Start it in foreground with :command:`./bin
 
 .. code-block:: console
 
-    ubuntu@training:/vagrant/buildout$ bin/instance fg
+    vagrant@training:/vagrant/buildout$ bin/instance fg
     2017-10-09 16:28:01 INFO ZServer HTTP server started at Mon Oct  9 16:28:01 2017
         Hostname: 0.0.0.0
         Port: 8080
@@ -304,21 +304,21 @@ It is in :file:`/vagrant/buildout/`. Start it in foreground with :command:`./bin
 
     ******************************************************************************
 
-    /home/ubuntu/buildout-cache/eggs/plone.formwidget.namedfile-2.0.4-py2.7.egg/plone/formwidget/namedfile/widget.py:18: DeprecationWarning: MimeTypeException is deprecated. Import from Products.MimetypesRegistry.interfaces instead
+    /home/vagrant/buildout-cache/eggs/plone.formwidget.namedfile-2.0.4-py2.7.egg/plone/formwidget/namedfile/widget.py:18: DeprecationWarning: MimeTypeException is deprecated. Import from Products.MimetypesRegistry.interfaces instead
       from Products.MimetypesRegistry.common import MimeTypeException
-    /home/ubuntu/buildout-cache/eggs/plone.app.dexterity-2.4.6-py2.7.egg/plone/app/dexterity/__init__.py:14: DeprecationWarning: Name clash, now use '_' as usual. Will be removed in Plone 5.2
+    /home/vagrant/buildout-cache/eggs/plone.app.dexterity-2.4.6-py2.7.egg/plone/app/dexterity/__init__.py:14: DeprecationWarning: Name clash, now use '_' as usual. Will be removed in Plone 5.2
       DeprecationWarning)
-    /home/ubuntu/buildout-cache/eggs/plone.app.multilingual-5.1.2-py2.7.egg/plone/app/multilingual/browser/migrator.py:11: DeprecationWarning: LanguageRootFolder: LanguageRootFolders should be migrate to DexterityContainers
+    /home/vagrant/buildout-cache/eggs/plone.app.multilingual-5.1.2-py2.7.egg/plone/app/multilingual/browser/migrator.py:11: DeprecationWarning: LanguageRootFolder: LanguageRootFolders should be migrate to DexterityContainers
       from plone.app.multilingual.content.lrf import LanguageRootFolder
-    /home/ubuntu/buildout-cache/eggs/plone.portlet.collection-3.2-py2.7.egg/plone/portlet/collection/collection.py:2: DeprecationWarning: isDefaultPage is deprecated. Import from Products.CMFPlone instead
+    /home/vagrant/buildout-cache/eggs/plone.portlet.collection-3.2-py2.7.egg/plone/portlet/collection/collection.py:2: DeprecationWarning: isDefaultPage is deprecated. Import from Products.CMFPlone instead
       from plone.app.layout.navigation.defaultpage import isDefaultPage
-    /home/ubuntu/buildout-cache/eggs/Products.CMFPlone-5.1rc1-py2.7.egg/Products/CMFPlone/browser/syndication/views.py:17: DeprecationWarning: wrap_form is deprecated. Import from plone.z3cform.layout instead.
+    /home/vagrant/buildout-cache/eggs/Products.CMFPlone-5.1rc1-py2.7.egg/Products/CMFPlone/browser/syndication/views.py:17: DeprecationWarning: wrap_form is deprecated. Import from plone.z3cform.layout instead.
       from plone.app.z3cform.layout import wrap_form
-    /home/ubuntu/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py:102: DeprecationWarning: Expected text
+    /home/vagrant/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py:102: DeprecationWarning: Expected text
       transaction.get().note("Created Zope Application")
-    /home/ubuntu/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py:265: DeprecationWarning: Expected text
+    /home/vagrant/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py:265: DeprecationWarning: Expected text
       transaction.get().note(note)
-    /home/ubuntu/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py:521: DeprecationWarning: Expected text
+    /home/vagrant/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py:521: DeprecationWarning: Expected text
       transaction.get().note('Prior to product installs')
     2017-10-09 16:28:07 INFO Zope Ready to handle requests
 
@@ -360,7 +360,7 @@ next to :file:`Vagrantfile` and :file:`manifests`.
 .. note::
 
     The database and the python packages are not accessible in your own system since large files cannot make use of symlinks in shared folders.
-    The database lies in ``/home/ubuntu/var``, the python packages are in ``/home/ubuntu/packages``.
+    The database lies in ``/home/vagrant/var``, the python packages are in ``/home/vagrant/packages``.
 
 If you have any problems or questions please mail us at team@starzel.de or create a ticket at https://github.com/plone/training/issues.
 

--- a/plone_training_config/manifests/host_setup.sh
+++ b/plone_training_config/manifests/host_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-AS_VAGRANT="sudo -u ubuntu"
+AS_VAGRANT="sudo -u vagrant"
 SHARED_DIR="/vagrant"
 
 # RUBY_PLATFORM=$1

--- a/plone_training_config/manifests/packages.pp
+++ b/plone_training_config/manifests/packages.pp
@@ -14,7 +14,6 @@ class packages {
   package { "libyaml-dev":       ensure => present, }
   package { "libz-dev":          ensure => present, }
   package { "nodejs":            ensure => present, }
-  package { "nodejs-legacy":     ensure => present, }
   package { "npm":               ensure => present, }
   package { "python-dev":        ensure => present, }
   package { "python-tk":         ensure => present, }

--- a/plone_training_config/manifests/plone.pp
+++ b/plone_training_config/manifests/plone.pp
@@ -2,27 +2,27 @@ class plone {
 
     $plone_version = "5.1.2"
 
-    file { ['/home/ubuntu/tmp',
-            '/home/ubuntu/.buildout',
-            '/home/ubuntu/buildout-cache',
-            '/home/ubuntu/buildout-cache/eggs',
-            '/home/ubuntu/buildout-cache/downloads',
-            '/home/ubuntu/buildout-cache/extends',
+    file { ['/home/vagrant/tmp',
+            '/home/vagrant/.buildout',
+            '/home/vagrant/buildout-cache',
+            '/home/vagrant/buildout-cache/eggs',
+            '/home/vagrant/buildout-cache/downloads',
+            '/home/vagrant/buildout-cache/extends',
             ]:
         ensure => directory,
-        owner => 'ubuntu',
-        group => 'ubuntu',
+        owner => 'vagrant',
+        group => 'vagrant',
         mode => '0755',
     }
 
-    file { '/home/ubuntu/.buildout/default.cfg':
+    file { '/home/vagrant/.buildout/default.cfg':
         ensure => present,
         content => inline_template('[buildout]
-eggs-directory = /home/ubuntu/buildout-cache/eggs
-download-cache = /home/ubuntu/buildout-cache/downloads
-extends-cache = /home/ubuntu/buildout-cache/extends'),
-        owner => 'ubuntu',
-        group => 'ubuntu',
+eggs-directory = /home/vagrant/buildout-cache/eggs
+download-cache = /home/vagrant/buildout-cache/downloads
+extends-cache = /home/vagrant/buildout-cache/extends'),
+        owner => 'vagrant',
+        group => 'vagrant',
         mode => '0664',
     }
 
@@ -40,19 +40,19 @@ extends-cache = /home/ubuntu/buildout-cache/extends'),
     # Create virtualenv
     exec {'virtualenv --no-site-packages py27':
         alias => "virtualenv",
-        creates => '/home/ubuntu/py27',
-        user => 'ubuntu',
-        cwd => '/home/ubuntu',
+        creates => '/home/vagrant/py27',
+        user => 'vagrant',
+        cwd => '/home/vagrant',
         before => Exec["install_buildout_setuptools"],
         timeout => 300,
     }
 
     # Install zc.buildout, setuptools
-    exec {'/home/ubuntu/py27/bin/pip install -r http://dist.plone.org/release/${plone_version}/requirements.txt':
+    exec {"/home/vagrant/py27/bin/pip install -r http://dist.plone.org/release/${plone_version}/requirements.txt":
         alias => "install_buildout_setuptools",
-        creates => '/home/ubuntu/py27/bin/buildout',
-        user => 'ubuntu',
-        cwd => '/home/ubuntu',
+        creates => '/home/vagrant/py27/bin/buildout',
+        user => 'vagrant',
+        cwd => '/home/vagrant',
         before => Exec["download_buildout_cache"],
         timeout => 0,
     }
@@ -61,40 +61,41 @@ extends-cache = /home/ubuntu/buildout-cache/extends'),
     # Try only once and rely on wget's default read timeout of 900s
     exec {"wget -t 1 http://dist.plone.org/release/${plone_version}/buildout-cache.tar.bz2":
         alias => "download_buildout_cache",
-        creates => "/home/ubuntu/buildout-cache.tar.bz2",
-        cwd => '/home/ubuntu',
-        user => 'ubuntu',
-        group => 'ubuntu',
+        creates => "/home/vagrant/buildout-cache.tar.bz2",
+        cwd => '/home/vagrant',
+        user => 'vagrant',
+        group => 'vagrant',
         before => Exec["unpack_buildout_cache"],
         returns => [0,8], # no error if tarball is unavailable
+        timeout => 0,
     }
 
-    # Unpack the buildout-cache to /home/ubuntu/buildout-cache/
-    exec {"tar xjf /home/ubuntu/buildout-cache.tar.bz2":
+    # Unpack the buildout-cache to /home/vagrant/buildout-cache/
+    exec {"tar xjf /home/vagrant/buildout-cache.tar.bz2":
         alias => "unpack_buildout_cache",
-        creates => "/home/ubuntu/buildout-cache/eggs/Products.CMFPlone-${plone_version}-py2.7.egg/",
-        user => 'ubuntu',
-        cwd => '/home/ubuntu',
+        creates => "/home/vagrant/buildout-cache/eggs/Products.CMFPlone-${plone_version}-py2.7.egg/",
+        user => 'vagrant',
+        cwd => '/home/vagrant',
         before => Exec["checkout_training"],
         timeout => 0,
-        onlyif => "test -f /home/ubuntu/buildout-cache.tar.bz2" # managed to dowload the tarball
+        onlyif => "test -f /home/vagrant/buildout-cache.tar.bz2" # managed to dowload the tarball
     }
 
     # get training buildout
-    exec {'git clone https://github.com/collective/training_buildout.git buildout':
+    exec {'git clone -b bionic_user_vagrant --single-branch https://github.com/collective/training_buildout.git buildout':
         alias => "checkout_training",
         creates => '/vagrant/buildout',
-        user => 'ubuntu',
+        user => 'vagrant',
         cwd => '/vagrant',
         before => Exec["buildout_training"],
         timeout => 0,
     }
 
     # run training buildout
-    exec {'/home/ubuntu/py27/bin/buildout -c vagrant_provisioning.cfg':
+    exec {'/home/vagrant/py27/bin/buildout -c vagrant_provisioning.cfg':
         alias => "buildout_training",
         creates => '/vagrant/buildout/bin/instance',
-        user => 'ubuntu',
+        user => 'vagrant',
         cwd => '/vagrant/buildout',
         # before => Exec["buildout_final"],
         timeout => 0,

--- a/plone_training_config/what_vagrant_does.rst
+++ b/plone_training_config/what_vagrant_does.rst
@@ -35,7 +35,6 @@ First we update Ubuntu and install some packages.
     $ sudo apt-get install libyaml-dev
     $ sudo apt-get install libz-dev
     $ sudo apt-get install nodejs
-    $ sudo apt-get install nodejs-legacy
     $ sudo apt-get install npm
     $ sudo apt-get install python-dev
     $ sudo apt-get install python-tk
@@ -52,14 +51,14 @@ Then we create a virtual python environment using virtualenv. This is always a g
 
 .. code-block:: bash
 
-    $ virtualenv --no-site-packages /home/ubuntu/py27
+    $ virtualenv --no-site-packages /home/vagrant/py27
 
 
 Install zc.buildout, setuptools and other dependencies for the current version into the new virtualenv.
 
 .. code-block:: bash
 
-    $ /home/ubuntu/py27/bin/pip install -r http://dist.plone.org/release/5.1.2/requirements.txt
+    $ /home/vagrant/py27/bin/pip install -r http://dist.plone.org/release/5.1.2/requirements.txt
 
 Now we download and unpack a buildout-cache that holds all the python packages that make up Plone. This is an optimisation: We could skip this step and have buildout download all packages individually from the `python packaging index PyPi <https://pypi.org>`_ but that takes much longer on a first install.
 
@@ -80,7 +79,7 @@ Then we run buildout:
 
 .. code-block:: bash
 
-    $ /home/ubuntu/py27/bin/buildout -c vagrant_provisioning.cfg
+    $ /home/vagrant/py27/bin/buildout -c vagrant_provisioning.cfg
 
 This will download many additional eggs that are not yet part of the buildout-cache and configure Plone to be ready to run.
 


### PR DESCRIPTION
Current Ubunutu LTS is 18.04 (Bionic Beaver). Important changes to the Vagrant setup:

* the `nodejs-legacy` package is no longer available (my interpretation is that we no longer need it because it's functionality is fully covered by `nodejs`, but this needs to be tested)

* Bionic uses `puppet` 5.4. This version allows curly braces around variable names only inside of double quoted strings (s https://puppet.com/docs/puppet/5.4/lang_variables.html#interpolation)

* The VM needs more than 1G of memory when `puppet` is running `buildout` (set to 1.5G for now)