### PR TITLE
Improves contrast of highlighted code via `emphasize-lines`

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -41,7 +41,13 @@
 .rst-content .toggle p:last-child {
     margin-bottom: 0;
 }
-
+/* improve contrast */
+.highlight .hll {
+    background-color: #ff9;
+}
+.highlight {
+    background: #fff;
+}
 @media screen and (max-width: 1200px){
 .wy-nav-content {
     max-width: 1100px !important;


### PR DESCRIPTION
This commit improves contrast of highlighted code via `emphasize-lines`.

It overrides the default values provided by the `pygments` style. The default styles are difficult to perceive when using a projector, as we experience during the training provided by @pbauer in Tokyo.

Specifically these styles have very little contrast between the background of the code sample and the highlighted lines:
```css
.highlight {
    background: #efc;
}
```
and
```css
.highlight .hll {
    background-color: #ff9;
}
```

## before
![google chrome007](https://user-images.githubusercontent.com/102112/49155594-2d2f6400-f2d0-11e8-93b3-91b62954118e.png)

## after
![google chrome006](https://user-images.githubusercontent.com/102112/49155602-315b8180-f2d0-11e8-83cb-572882cb3b3a.png)
