### PR TITLE
Use behavior shortnames and fixes within the behavior explanation/ usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ This changelog is only very rough. For the full changelog please refer to https:
 1.2.5 (unreleased)
 ------------------
 
+- Minor fixes, like using implementer and provider decorators [jensens]
+
+- Use behavior shortnames as best practice. [jensens]
+
+- Refine misleading explanation of IFormFieldProvider [jensens]
+
 - Tweaks to Mastering Plone testing page [tkimnguyen]
 
 - Fix React and Volto bootstrapping information. [jensens]

--- a/_locales/addons.pot
+++ b/_locales/addons.pot
@@ -68,7 +68,7 @@ msgstr ""
 
 #: ../addons.rst:17
 # 2073228af2534d02ac5e1cd03836d27a
-msgid "google (e.g. `Plone+Slider <http://lmgtfy.com/?q=plone+slider>`_)"
+msgid "google (e.g. `Plone+Slider <http://google.com/?q=plone+slider>`_)"
 msgstr ""
 
 #: ../addons.rst:18

--- a/_locales/es/LC_MESSAGES/addons.po
+++ b/_locales/es/LC_MESSAGES/addons.po
@@ -74,8 +74,8 @@ msgstr "http://news.gmane.org/gmane.comp.web.zope.plone.user"
 
 # 2073228af2534d02ac5e1cd03836d27a
 #: ../addons.rst:17
-msgid "google (e.g. `Plone+Slider <http://lmgtfy.com/?q=plone+slider>`_)"
-msgstr "google (por ejemplo `Plone+Slider <http://lmgtfy.com/?q=plone+slider>`_)"
+msgid "google (e.g. `Plone+Slider <http://google.com/?q=plone+slider>`_)"
+msgstr "google (por ejemplo `Plone+Slider <http://google.com/?q=plone+slider>`_)"
 
 # 44b928fa38b04b80a2d579ad3d643fc3
 #: ../addons.rst:18

--- a/mastering-plone/add-ons.rst
+++ b/mastering-plone/add-ons.rst
@@ -79,7 +79,7 @@ It can be very hard to find the right addon for your requirements. Here are some
   * https://pypi.org >3400 Plone related packages - use the search form!
   * https://github.com/collective >1500 repos
   * https://github.com/plone >310 repos
-  * google (e.g. `Plone+Slider <http://lmgtfy.com/?q=plone+slider>`_)
+  * google (e.g. `Plone+Slider <http://google.com/?q=plone+slider>`_)
 
 * Once you have a shortlist test these addons. Here are the main issues you need to test before you install a addon on a production site:
 

--- a/mastering-plone/behaviors_1.rst
+++ b/mastering-plone/behaviors_1.rst
@@ -103,6 +103,7 @@ Then, we add an empty :file:`behaviors/__init__.py` and a :file:`behaviors/confi
 
       <plone:behavior
           title="Social Behavior"
+          name="ploneconf.social"
           description="Adds a link to lanyrd"
           provides=".social.ISocial"
           />
@@ -121,9 +122,9 @@ And a :file:`behaviors/social.py` containing:
     from plone.supermodel import directives
     from plone.supermodel import model
     from zope import schema
-    from zope.interface import alsoProvides
+    from zope.interface import provider
 
-
+    @provider(IFormFieldProvider)
     class ISocial(model.Schema):
 
         directives.fieldset(
@@ -138,7 +139,6 @@ And a :file:`behaviors/social.py` containing:
             required=False,
         )
 
-    alsoProvides(ISocial, IFormFieldProvider)
 
 .. only:: not presentation
 
@@ -147,9 +147,9 @@ And a :file:`behaviors/social.py` containing:
     #. We register a behavior in :ref:`behaviors/configure.zcml <social-behavior-zcml-label>`. We do not say for which content type this behavior is valid. You do this through the web or in the GenericSetup profile.
     #. We create a marker interface in :ref:`behaviors/social.py <social-behavior-python-label>` for our behavior and make it also a schema containing the fields we want to declare.
        We could just define schema fields on a zope.interface class, but we use an extended form from `plone.supermodel`_, else we could not use the fieldset features.
+    #. We mark our schema as a class that also provides the `IFormFieldProvider`_ interface using a decorator. The schema class itself provides the interface, not its instance!
     #. We also add a `fieldset`_ so that our fields are not mixed with the normal fields of the object.
     #. We add a normal `URI <https://zopeschema.readthedocs.io/en/latest/fields.html#uri>`_ schema field to store the URI to lanyrd.
-    #. We mark our schema as a class that also implements the `IFormFieldProvider`_ interface. This is a marker interface, we do not need to implement anything to provide the interface.
 
 .. _behaviors1-adding-label:
 
@@ -171,9 +171,9 @@ We must add the behavior to :file:`profiles/default/types/talk.xml`:
        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
        ...
      <property name="behaviors">
-      <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-      <element value="plone.app.content.interfaces.INameFromTitle"/>
-      <element value="ploneconf.site.behaviors.social.ISocial"/>
+      <element value="plone.dublincore"/>
+      <element value="plone.namefromtitle"/>
+      <element value="ploneconf.social"/>
      </property>
      ...
     </object>

--- a/mastering-plone/behaviors_1.rst
+++ b/mastering-plone/behaviors_1.rst
@@ -24,7 +24,8 @@ Topics covered:
 
     You can extend the functionality of your dexterity object by writing an adapter that adapts your dexterity object to add another feature or aspect.
 
-    But if you want to use this adapter, you must somehow know that an object implements that. Also, adding more fields to an object would not be easy with such an approach.
+    But if you want to use this adapter, you must somehow know that an object implements that.
+    Also, adding more fields to an object would not be easy with such an approach.
 
 .. _behaviors1-dexterity-label:
 
@@ -37,7 +38,8 @@ Dexterity Approach
 
     A behavior can be added to any content type through the web and at runtime.
 
-    All default views (e.g. the add- and edit-forms) know about the concept of behaviors and when rendering forms, the views also check whether there are behaviors referenced with the current context and if these behaviors have a schema of their own, these fields get shown in addition.
+    All default views (e.g. the add- and edit-forms) know about the concept of behaviors.
+    When rendering forms, the views also check whether there are behaviors referenced with the current context and if these behaviors have a schema of their own, these fields get shown in addition.
 
 .. _behaviors1-names-label:
 
@@ -46,7 +48,10 @@ Names and Theory
 
 .. only:: not presentation
 
-    The name behavior is not a standard term in software development. But it is a good idea to think of a behavior as an aspect. You are adding an aspect to your content type and you want to write your aspect in such a way that it works independently of the content type on which the aspect is applied. You should not have dependencies to specific fields of your object or to other behaviors.
+    The name behavior is not a standard term in software development.
+    But it is a good idea to think of a behavior as an aspect.
+    You are adding an aspect to your content type and you want to write your aspect in such a way that it works independently of the content type on which the aspect is applied.
+    You should not have dependencies to specific fields of your object or to other behaviors.
 
     Such an object allows you to apply the `Open/closed principle`_ to your dexterity objects.
 
@@ -83,9 +88,11 @@ Then, we add an empty :file:`behaviors/__init__.py` and a :file:`behaviors/confi
 
         It can be a bit confusing when to use factories or marker interfaces and when not to.
 
-        If you do not define a factory, your attributes will be stored directly on the object. This can result in clashes with other behaviors.
+        If you do not define a factory, your attributes will be stored directly on the object.
+        This can result in clashes with other behaviors.
 
-        You can avoid this by using the :py:class:`plone.behavior.AnnotationStorage` factory. This stores your attributes in an `Annotation <https://docs.plone.org/develop/plone/misc/annotations.html>`_.
+        You can avoid this by using the :py:class:`plone.behavior.AnnotationStorage` factory.
+        This stores your attributes in an `Annotation <https://docs.plone.org/develop/plone/misc/annotations.html>`_.
         But then you *must* use a marker interface if you want to have custom viewlets, browser views or portlets.
 
         Without it, you would have no interface against which you could register your views.
@@ -144,10 +151,14 @@ And a :file:`behaviors/social.py` containing:
 
     Let's go through this step by step.
 
-    #. We register a behavior in :ref:`behaviors/configure.zcml <social-behavior-zcml-label>`. We do not say for which content type this behavior is valid. You do this through the web or in the GenericSetup profile.
-    #. We create a marker interface in :ref:`behaviors/social.py <social-behavior-python-label>` for our behavior and make it also a schema containing the fields we want to declare.
+    #. We register a behavior in :ref:`behaviors/configure.zcml <social-behavior-zcml-label>`.
+       We do not say for which content type this behavior is valid.
+       You do this through the web or in the GenericSetup profile.
+    #. We create a marker interface in :ref:`behaviors/social.py <social-behavior-python-label>` for our behavior.
+       We make it also a schema containing the fields we want to declare.
        We could just define schema fields on a zope.interface class, but we use an extended form from `plone.supermodel`_, else we could not use the fieldset features.
-    #. We mark our schema as a class that also provides the `IFormFieldProvider`_ interface using a decorator. The schema class itself provides the interface, not its instance!
+    #. We mark our schema as a class that also provides the `IFormFieldProvider`_ interface using a decorator.
+       The schema class itself provides the interface, not its instance!
     #. We also add a `fieldset`_ so that our fields are not mixed with the normal fields of the object.
     #. We add a normal `URI <https://zopeschema.readthedocs.io/en/latest/fields.html#uri>`_ schema field to store the URI to lanyrd.
 
@@ -158,7 +169,8 @@ Adding it to our talk
 
 .. only:: not presentation
 
-    We could add this behavior now via the plone control panel. But instead, we will do it directly and properly in our GenericSetup profile
+    We could add this behavior now via the plone control panel.
+    But instead, we will do it directly and properly in our GenericSetup profile
 
 We must add the behavior to :file:`profiles/default/types/talk.xml`:
 

--- a/mastering-plone/behaviors_2.rst
+++ b/mastering-plone/behaviors_2.rst
@@ -187,12 +187,12 @@ The interfaces need to be written, in our case into a file :file:`interfaces.py`
 .. only:: not presentation
 
     This is a lot of code.
-    The IVotableLayer we will need later for viewlets and browser views.
+    The ``IVotableLayer`` we will need later for viewlets and browser views.
     Let's add it right here.
-    The IVotable interface is the simple marker interface.
+    The ``IVotable`` interface is the simple marker interface.
     It will only be used to bind browser views and viewlets to contenttypes that provide our behavior, so no code needed.
 
-    The IVoting class is more complex, as you can see.
+    The ``IVoting`` class is more complex, as you can see.
 
     The ``@provider`` decorator above the class ensures that the schema fields are known to other packages.
     Whenever some code wants all schemas from an object, it receives the schema defined directly on the object and the additional schemata.

--- a/mastering-plone/behaviors_2.rst
+++ b/mastering-plone/behaviors_2.rst
@@ -357,7 +357,7 @@ Let's continue with this file:
     There are many ways to ensure this and each one has flaws.
 
     We chose this way to show you how to access information from the request the browser of the user sent to us.
-    First, we get the ip of the user, then we access a small set of headers from the user's browser and generate an md5 checksum of this.
+    First, we get the IP address of the user, then we access a small set of headers from the user's browser and generate an md5 checksum of this.
 
     The vote method wants a vote and a request. We check the preconditions, then we convert the vote to an integer, store the request to ``voted`` and the votes into the ``votes`` dictionary.
     We just count there how often any vote has been given.

--- a/mastering-plone/behaviors_2.rst
+++ b/mastering-plone/behaviors_2.rst
@@ -434,7 +434,7 @@ The test should raise a ``ConflictError`` on the original voting behavior implem
 The solution from the first exercise should pass.
 Look at the file ``ZODB/ConflictResolution.txt`` in the ``ZODB3`` egg for how to create a suitable test fixture for conflict testing.
 Look at the test code in ``zope.annotation`` for how to create annotatable dummy content.
-You will also have to write a 'request' dummy that mocks the ``getClientAddr`` and ``getHeader`` methods of Zope's HTTP request object to make the `_hash` method of the voting behavior work.
+You will also have to write a 'request' dummy that mocks the ``getClientAddr`` and ``getHeader`` methods of Zope's HTTP request object to make the ``_hash`` method of the voting behavior work.
 
 ..  admonition:: Solution
     :class: toggle
@@ -443,7 +443,7 @@ You will also have to write a 'request' dummy that mocks the ``getClientAddr`` a
     But you can refer to chapter 22 for how to setup unit testing for a package.
     Put the particular test for this exercise into a file named :file:`starzel.votable_behavior/starzel/votable_behavior/tests/test_voting`.
     Remember you need an empty :file:`__init__.py` file in the :file:`tests` directory to make testing work.
-    You also need to add `starzel.votable_behavior` to `test-eggs` in :file:`buildout.cfg` and re-run buildout.`
+    You also need to add ``starzel.votable_behavior`` to ``test-eggs`` in :file:`buildout.cfg` and re-run buildout.
 
     .. code-block:: python
         :linenos:

--- a/mastering-plone/behaviors_2.rst
+++ b/mastering-plone/behaviors_2.rst
@@ -17,11 +17,15 @@ Using Annotations
 -----------------
 .. only:: not presentation
 
-    We are going to store the information in an annotation. Not because it is needed but because you will find code that uses annotations and need to understand the implications.
+    We are going to store the information in an annotation.
+    Not because it is needed but because you will find code that uses annotations and need to understand the implications.
 
-    `Annotations`_ in Zope/Plone mean that data won't be stored directly on an object but in an indirect way and with namespaces so that multiple packages can store information under the same attribute, without colliding.
+    `Annotations`_ in Zope/Plone mean that data won't be stored directly on an object but in an indirect way with namespaces so that multiple packages can store information under the same attribute, without colliding.
 
-    So using annotations avoids namespace conflicts. The cost is an indirection. The dictionary is persistent so it has to be stored separately. Also, one could give attributes a name containing a namespace prefix to avoid naming collisions.
+    So using annotations avoids namespace conflicts.
+    The cost is an indirection.
+    The dictionary is persistent so it has to be stored separately.
+    Also, one could give attributes a name containing a namespace prefix to avoid naming collisions.
 
 .. only:: presentation
 
@@ -37,9 +41,12 @@ Using Schema
 
 .. only:: not presentation
 
-    The attribute where we store our data will be declared as a schema field. We mark the field as an omitted field (using schema directive similar to ``read_permission`` or ``widget``), because we are not going to create :py:mod:`z3c.form` widgets for entering or displaying them. We do provide a schema, because many other packages use the schema information to get knowledge of the relevant fields.
+    The attribute where we store our data will be declared as a schema field.
+    We mark the field as an omitted field (using schema directive similar to ``read_permission`` or ``widget``), because we are not going to create :py:mod:`z3c.form` widgets for entering or displaying them.
+    We do provide a schema, because many other packages use the schema information to get knowledge of the relevant fields.
 
-    For example, when files were migrated to blobs, new objects had to be created and every schema field was copied. The code can't know about our field, except if we provide schema information.
+    For example, when files were migrated to blobs, new objects had to be created and every schema field was copied.
+    The code can not know about our field, except if we provide schema information.
 
 .. only:: presentation
 
@@ -96,11 +103,13 @@ There are some important differences to our first behavior:
 .. only:: not presentation
 
     The factory is a class that provides the behavior logic and gives access to the attributes we provide.
-    Factories in Plone/Zope land are retrieved by adapting an object to an interface.
-    If you want your behavior, you would write :samp:`IVoting(object)`
+    Factories in Plone/Zope land are retrieved by adapting an object to an interface and are following the adapter pattern.
+    If you want your behavior, you would write ``voting = IVoting(object)``.
 
-    But in order for this to work, your object may *not* be implementing the IVoting interface, because if it did, :samp:`IVoting(object)` would return the object itself!
-    If I need a marker interface for objects providing my behavior, I must provide one, for this we use the marker attribute. My object implements :samp:`IVotable` and because of this, we can write views and viewlets just for this content type.
+    But in order for this to work, your object may *not* be implementing the ``IVoting`` interface, because if it did,  ``IVoting(object)`` would return the object itself!
+    If I need a marker interface for objects providing my behavior, I must provide one, for this we use the marker attribute.
+    My object implements ``IVotable``.
+    Because of this, we can write views and viewlets just for this content type.
 
 The interfaces need to be written, in our case into a file :file:`interfaces.py`:
 
@@ -177,26 +186,30 @@ The interfaces need to be written, in our case into a file :file:`interfaces.py`
 
 .. only:: not presentation
 
-    This is a lot of code. The IVotableLayer we will need later for viewlets and browser views. Let's add it right here.
-    The IVotable interface is the simple marker interface. It will only be used to bind browser views and viewlets to contenttypes that provide our behavior, so no code needed.
+    This is a lot of code.
+    The IVotableLayer we will need later for viewlets and browser views.
+    Let's add it right here.
+    The IVotable interface is the simple marker interface.
+    It will only be used to bind browser views and viewlets to contenttypes that provide our behavior, so no code needed.
 
     The IVoting class is more complex, as you can see.
 
-    The :samp:`@provider` decorator above the class ensures that the schema fields are known to other packages.
+    The ``@provider`` decorator above the class ensures that the schema fields are known to other packages.
     Whenever some code wants all schemas from an object, it receives the schema defined directly on the object and the additional schemata.
-    Additional schemata are compiled by looking for behaviors and whether they provide the :samp:`IFormFieldProvider` functionality.
+    Additional schemata are compiled by looking for behaviors and whether they provide the ``IFormFieldProvider``functionality.
     Only then the fields are used as form fields.
 
-    While IVoting is just an interface, we use :samp:`plone.supermodel.model.Schema` for advanced dexterity features.
-    Zope.schema provides no means for hiding fields.
+    While IVoting is just an interface, we use ``plone.supermodel.model.Schema`` for advanced dexterity features.
+    ``zope.schema`` provides no means for hiding fields.
 
-    The directives :samp:`form.omitted` from :samp:`plone.autoform` allow us to annotate this additional information so that the autoform renderers for forms can use the additional information.
-    We make this omit conditional. If we run Plone in debug mode, we will be able to see the internal data in the edit form.
+    The directives ``form.omitted`` from ``plone.autoform`` allow us to annotate this additional information so that the autoform renderers for forms can use the additional information.
+    We make this omit conditional.
+    If we run Plone in debug mode, we will be able to see the internal data in the edit form.
 
     We create minimal schema fields for our internal data structures.
-    For a small test, I removed the form omitted directives and opened the edit view of a talk that uses the behavior. After seeing the ugliness, I decided that I should provide at least  minimum of information.
-    Titles and required are purely optional, but very helpful if the fields won't be omitted, something that can be helpful when debugging the behavior.
-    Later, when we implement the behavior, the :samp:`votes` and :samp:`voted` attributes are implemented in such a way that you can't just modify these fields, they are read only.
+    For a small test, I removed the form omitted directives and opened the edit view of a talk that uses the behavior. After seeing the ugliness, I decided that I should provide at least minimum of information.
+    ``title`` and ``required`` are purely optional, but very helpful if the fields won't be omitted, something that can be helpful when debugging the behavior.
+    Later, when we implement the behavior, the ``votes`` and ``voted`` attributes are implemented in such a way that you can't just modify these fields, they are read only.
 
     Then we define the API that we are going to use in browser views and viewlets.
 
@@ -239,36 +252,49 @@ Now the only thing that is missing is the behavior implementation, which we must
 
 .. only:: not presentation
 
-    In our :samp:`__init__` method we get *annotations* from the object.
+    In our ``__init__`` method we get *annotations* from the object.
     We look for data with a specific key.
 
-    The key in this example is the same as what I would get with :samp:`__name__+Vote.__name__`. But we won't create a dynamic name, this would be very clever and clever is bad.
+    The key in this example is the same as what I would get with ``__name__+Vote.__name__``.
+    But we won't create a dynamic name, this would be very clever and clever is bad.
 
     By declaring a static name, we won't run into problems if we restructure the code.
 
-    You can see that we initialize the data if it doesn't exist. We work with PersistentDict and PersistentList.
+    You can see that we initialize the data if it doesn't exist.
+    We work with ``PersistentDict`` and ``PersistentList``.
     To understand why we do this, it is important to understand how the ZODB works.
 
     .. seealso::
 
-        The ZODB can store objects. It has a special root object that you will never touch. Whatever you store there, will be part of the root object, except if it is an object subclassing :samp:`persistent.Persistent` Then it will be stored independently.
+        The ZODB can store objects.
+        It has a special root object that you will never touch.
+        Whatever you store there, will be part of the root object, except if it is an object subclassing ``persistent.Persistent``. Then it will be stored independently.
 
-        Zope/ZODB Persistent objects note when you change an attribute on it and mark itself as changed. Changed objects will be saved to the database. This happens automatically. Each request begins a transaction and after our code runs and the Zope Server is preparing to send back the response we generated, the transaction will be committed and everything we changed will be saved.
+        Zope/ZODB persistent objects note when you change an attribute on it and mark itself as changed.
+        Changed objects will be saved to the database.
+        This happens automatically.
+        Each request begins a transaction and after our code runs and the Zope Server is preparing to send back the response we generated, the transaction will be committed and everything we changed will be saved.
 
-        Now, if have a normal dictionary on a persistent object, and you will only change the dictionary, the persistent object has no way to know if the dictionary has been changed. This `happens`_ from time to time.
+        Now, if have a normal dictionary on a persistent object, and you will only change the dictionary, the persistent object has no way to know if the dictionary has been changed.
+        This `happens`_ from time to time.
 
-        So one solution is to change the special attribute :samp:`_p_changed` to :samp:`True` on the persistent object, or to use a PersistentDict. That is what we are doing here.
+        So one solution is to change the special attribute ``_p_changed`` to ``True`` (or any other value!) on the persistent object, or to use a ``PersistentDict``.
+        Latter is what we are doing here.
 
-        An important thing to note about PersistentDict and PersistentList is that they cannot handle write conflicts. What happens if two users rate the same content independently at the same time?
-        In this case, a database conflict will occur because there is no way for Plone to know how to handle the concurrent write access. Although this is rather unlikely during
-        this training, it is a very common problem on high traffic websites.
+        An important thing to note about ``PersistentDict`` and ``PersistentList`` is that they cannot handle write conflicts.
+        What happens if two users rate the same content independently at the same time?
+        In this case, a database conflict will occur because there is no way for Plone to know how to handle the concurrent write access.
+        Although this is rather unlikely during this training, it is a very common problem on high traffic websites.
 
         You can find more information in the documentation of the ZODB, in particular `Rules for Persistent Classes <http://www.zodb.org/en/latest/guide/writing-persistent-objects.html>`_
 
 
-    Next we provide the internal fields via properties. Using this form of property makes them read only properties, as we did not define write handlers. We don't need them so we won't add them.
+    Next we provide the internal fields via properties.
+    Using this form of property makes them read only properties, as we did not define write handlers.
+    We don't need them so we won't add them.
 
-    As you have seen in the Schema declaration, if you run your site in debug mode, you will see an edit field for these fields. But trying to change these fields will throw an exception.
+    As you have seen in the Schema declaration, if you run your site in debug mode, you will see an edit field for these fields.
+    But trying to change these fields will throw an exception.
 
     .. _happens: https://github.com/plone/Products.CMFEditions/commit/5c07c72bc8701cf28c9cc68ad940186b9e296ddf
 
@@ -288,8 +314,7 @@ Let's continue with this file:
             """
             hash_ = md5()
             hash_.update(request.getClientAddr())
-            for key in ["User-Agent", "Accept-Language",
-                        "Accept-Encoding"]:
+            for key in ["User-Agent", "Accept-Language", "Accept-Encoding"]:
                 hash_.update(request.getHeader(key))
             return hash_.hexdigest()
 
@@ -308,8 +333,8 @@ Let's continue with this file:
             if not has_votes(self):
                 return 0
             total_votes = sum(self.annotations['votes'].values())
-            total_points = sum([vote * count for (vote, count) in
-                                self.annotations['votes'].items()])
+            total_points = sum(
+                [vote * count for (vote, count) in self.annotations['votes'].items()])
             return float(total_points) / total_votes
 
         def has_votes(self):
@@ -320,19 +345,21 @@ Let's continue with this file:
 
         def clear(self):
             annotations = IAnnotations(self.context)
-            annotations[KEY] = PersistentDict({'voted': PersistentList(),
-                                               'votes': PersistentDict()})
+            annotations[KEY] = PersistentDict(
+                {'voted': PersistentList(), 'votes': PersistentDict()}
+            )
             self.annotations = annotations[KEY]
 
 .. only:: not presentation
 
-    We start with a little helper method which is not exposed via the interface. We don't want people to vote twice.
+    We start with a little helper method which is not exposed via the interface.
+    We don't want people to vote twice.
     There are many ways to ensure this and each one has flaws.
 
     We chose this way to show you how to access information from the request the browser of the user sent to us.
     First, we get the ip of the user, then we access a small set of headers from the user's browser and generate an md5 checksum of this.
 
-    The vote method wants a vote and a request. We check the preconditions, then we convert the vote to an integer, store the request to :samp:`voted` and the votes into the :samp:`votes` dictionary.
+    The vote method wants a vote and a request. We check the preconditions, then we convert the vote to an integer, store the request to ``voted`` and the votes into the ``votes`` dictionary.
     We just count there how often any vote has been given.
 
     Everything else is just python.
@@ -343,8 +370,8 @@ Exercises
 Exercise 1
 ++++++++++
 
-Refactor the voting behavior so that it uses `BTrees` instead of `PersistentDict` and `PersistentList`.
-Use `OOBTree` to replace `PersistentDict` and `OIBTree` to replace `PersistentList`.
+Refactor the voting behavior so that it uses ``BTrees`` instead of ``PersistentDict`` and ``PersistentList``.
+Use `OOBTree` to replace ``PersistentDict`` and ``OIBTree`` to replace ``PersistentList``.
 
 ..  admonition:: Solution
     :class: toggle
@@ -402,18 +429,21 @@ Use `OOBTree` to replace `PersistentDict` and `OIBTree` to replace `PersistentLi
 Exercise 2
 ++++++++++
 
-Write a unit test that simulates concurrent voting. The test should raise a `ConflictError` on the original voting behavior implementation.
-The solution from the first exercise should pass. Look at the file `ZODB/ConflictResolution.txt` in the `ZODB3` egg for how to create a suitable test fixture for conflict testing.
-Look at the test code in `zope.annotation` for how to create annotatable dummy content.
-You will also have to write a 'request' dummy that mocks the `getClientAddr` and `getHeader` methods of Zope's HTTP request object to make the `_hash` method of the voting behavior work.
+Write a unit test that simulates concurrent voting.
+The test should raise a ``ConflictError`` on the original voting behavior implementation.
+The solution from the first exercise should pass.
+Look at the file ``ZODB/ConflictResolution.txt`` in the ``ZODB3`` egg for how to create a suitable test fixture for conflict testing.
+Look at the test code in ``zope.annotation`` for how to create annotatable dummy content.
+You will also have to write a 'request' dummy that mocks the ``getClientAddr`` and ``getHeader`` methods of Zope's HTTP request object to make the `_hash` method of the voting behavior work.
 
 ..  admonition:: Solution
     :class: toggle
 
-    There are no tests for `starzel.votablebehavior` at all at the moment. But you can refer to chapter 22 for how to setup unit testing for a package.
+    There are no tests for `starzel.votablebehavior` at all at the moment.
+    But you can refer to chapter 22 for how to setup unit testing for a package.
     Put the particular test for this exercise into a file named :file:`starzel.votable_behavior/starzel/votable_behavior/tests/test_voting`.
-    Remember you need an empty :file:`__init__.py` file in the :file:`tests` directory to make testing work. You also need to add `starzel.votable_behavior` to
-    `test-eggs` in :file:`buildout.cfg` and re-run buildout.
+    Remember you need an empty :file:`__init__.py` file in the :file:`tests` directory to make testing work.
+    You also need to add `starzel.votable_behavior` to `test-eggs` in :file:`buildout.cfg` and re-run buildout.`
 
     .. code-block:: python
         :linenos:

--- a/mastering-plone/buildout_1.rst
+++ b/mastering-plone/buildout_1.rst
@@ -44,7 +44,6 @@ Here is a functioning minimal example from https://github.com/collective/minimal
     recipe = plone.recipe.zope2instance
     eggs =
         Plone
-        Pillow
 
 .. _buildout1-syntax-label:
 
@@ -147,7 +146,6 @@ Let us walk through the :file:`buildout.cfg` for the training and look at some i
 
     eggs =
         Plone
-        Pillow
 
     # development tools
         plone.reload
@@ -191,7 +189,6 @@ Let us walk through the :file:`buildout.cfg` for the training and look at some i
     recipe = zc.recipe.egg
     eggs =
         ${buildout:test-eggs}
-        Pillow
         plone.app.robotframework[ride,reload,debug]
 
     [packages]
@@ -250,7 +247,6 @@ When you run :command:`./bin/buildout` without any arguments, Buildout will look
 
         eggs =
             Plone
-            Pillow
 
         # development tools
             z3c.jbot

--- a/mastering-plone/dexterity_2.rst
+++ b/mastering-plone/dexterity_2.rst
@@ -68,6 +68,7 @@ So let's register the interface as a behavior in :file:`behaviors/configure.zcml
 
   <plone:behavior
       title="Talk"
+      name="ploneconf.talk"
       description="Marker interface for talks to be able to bind views to."
       provides="..interfaces.ITalk"
       />
@@ -79,10 +80,10 @@ And enable it on the type in :file:`profiles/default/types/talk.xml`
     :emphasize-lines: 5
 
     <property name="behaviors">
-     <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-     <element value="plone.app.content.interfaces.INameFromTitle"/>
-     <element value="ploneconf.site.behaviors.social.ISocial"/>
-     <element value="ploneconf.site.interfaces.ITalk"/>
+     <element value="plone.dublincore"/>
+     <element value="plone.namefromtitle"/>
+     <element value="ploneconf.social"/>
+     <element value="ploneconf.talk"/>
     </property>
 
 Either reinstall the add-on, apply the behavior by hand or run an upgrade step (see below) and the interface will be there.
@@ -624,11 +625,11 @@ Finally you need to activate the versioning behavior on the content type. Edit :
     :emphasize-lines: 6
 
     <property name="behaviors">
-     <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-     <element value="plone.app.content.interfaces.INameFromTitle"/>
-     <element value="ploneconf.site.behaviors.social.ISocial"/>
-     <element value="ploneconf.site.interfaces.ITalk"/>
-     <element value="plone.app.versioningbehavior.behaviors.IVersionable" />
+     <element value="plone.dublincore"/>
+     <element value="plone.namefromtitle"/>
+     <element value="ploneconf.social"/>
+     <element value="ploneconf.talk"/>
+     <element value="plone.versioning" />
     </property>
 
 .. note::

--- a/mastering-plone/dexterity_2.rst
+++ b/mastering-plone/dexterity_2.rst
@@ -447,7 +447,7 @@ The new indexes behave like the ones that Plone has already built in:
     >>> (Pdb) brain.speaker
     u'David Glick'
 
-We now can use the new indexes to improve the talklistview so we don't have to *wake up* the objects any more.
+We now can use the new indexes to improve the ``talklistview`` so we don't have to *wake up* the objects any more.
 Instead we use the brains' new attributes.
 
 .. code-block:: python
@@ -473,7 +473,7 @@ Instead we use the brains' new attributes.
                     })
             return results
 
-The template does not need to be changed and the result in the browser did not change, either.
+The template does not need to be changed and the result in the browser did not change either.
 But when listing a large number of objects the site will now be faster since all the data you use comes from the catalog and the objects do not have to be loaded into memory.
 
 
@@ -559,8 +559,8 @@ Modify :py:class:`TalkListView` to return only brains and adapt the template to 
 Add collection criteria
 -----------------------
 
-To be able to search content in collections using these new indexes we would have to register them as criteria for the querystring widget that collections use.
-s with all features make sure you only do this if you really need it!
+To be able to search content in collections using these new indexes we would have to register them as criteria for the ``querystring`` widget that collections use.
+As with all features make sure you only do this if you really need it!
 
 
 Add a new file :file:`profiles/default/registry.xml`

--- a/mastering-plone/dexterity_2.rst
+++ b/mastering-plone/dexterity_2.rst
@@ -31,9 +31,12 @@ Marker Interfaces
 +++++++++++++++++
 
 The content type `Talk` is not yet a *first class citizen* because it does not implement its own interface.
-Interfaces are like nametags, telling other elements who and what you are and what you can do. A marker interface is like such a nametag. The talks actually have an auto-generated marker interface ``plone.dexterity.schema.generated.Plone_0_talk``.
+Interfaces are like nametags, telling other elements who and what you are and what you can do.
+A marker interface is like such a nametag.
+The talks actually have an auto-generated marker interface ``plone.dexterity.schema.generated.Plone_0_talk``.
 
-One problem is that the name of the Plone instance ``Plone`` is part of that interface name. If you now moved these types to a site with another name the code that uses these interfaces would no longer find the objects in question.
+One problem is that the name of the Plone instance ``Plone`` is part of that interface name.
+If you now moved these types to a site with another name the code that uses these interfaces would no longer find the objects in question.
 
 To create a real name-tag we add a new :py:class:`Interface` to :file:`interfaces.py`:
 
@@ -55,12 +58,17 @@ To create a real name-tag we add a new :py:class:`Interface` to :file:`interface
     class ITalk(Interface):
         """Marker interface for Talks"""
 
-:py:class:`ITalk` is a marker interface. We can bind Views and Viewlets to content that provide these interfaces. Lets see how we can provide this Interface. There are two solutions for this.
+:py:class:`ITalk` is a marker interface.
+We can bind Views and Viewlets to content that provide these interfaces.
+Lets see how we can provide this Interface.
+
+There are two solutions for this.
 
 1. Let them be instances of a class that implements this Interface.
 2. Register this interface as a behavior and enable it on talks.
 
-The first option has an important drawback: only *new* talks would be instances of the new class. We would either have to migrate the existing talks or delete them.
+The first option has an important drawback: only *new* talks would be instances of the new class.
+We would either have to migrate the existing talks or delete them.
 
 So let's register the interface as a behavior in :file:`behaviors/configure.zcml`
 
@@ -102,7 +110,8 @@ Then we can safely bind the ``talkview`` to the new marker interface.
         permission="zope2.View"
         />
 
-Now the ``/talkview`` can only be used on objects that implement said interface. We can now also query the catalog for objects providing this interface :py:meth:`catalog(object_provides="ploneconf.site.interfaces.ITalk")`. The ``talklistview`` and the ``demoview`` do not get this constraint since they are not only used on talks.
+Now the ``/talkview`` can only be used on objects that implement said interface. We can now also query the catalog for objects providing this interface :py:meth:`catalog(object_provides="ploneconf.site.interfaces.ITalk")`.
+The ``talklistview`` and the ``demoview`` do not get this constraint since they are not only used on talks.
 
 .. note::
 
@@ -132,22 +141,27 @@ Now the ``/talkview`` can only be used on objects that implement said interface.
           <property name="behaviors">
           ...
 
-    * Create an upgrade step that changes the class of the existing talks. A reuseable method to do such a thing is in `plone.app.contenttypes.migration.dxmigration.migrate_base_class_to_new_class <https://github.com/plone/plone.app.contenttypes/blob/master/plone/app/contenttypes/migration/dxmigration.py#L130>`_.
+    * Create an upgrade step that changes the class of the existing talks.
+      A reuseable method to do such a thing is in `plone.app.contenttypes.migration.dxmigration.migrate_base_class_to_new_class <https://github.com/plone/plone.app.contenttypes/blob/master/plone/app/contenttypes/migration/dxmigration.py#L130>`_.
 
 .. _dexterity2-upgrades-label:
 
 Upgrade steps
 -------------
 
-When projects evolve you sometimes want to modify various things while the site is already up and brimming with content and users. Upgrade steps are pieces of code that run when upgrading from one version of an add-on to a newer one. They can do just about anything.
+When projects evolve you sometimes want to modify various things while the site is already up and brimming with content and users.
+Upgrade steps are pieces of code that run when upgrading from one version of an add-on to a newer one.
+They can do just about anything.
 We will use an upgrade-step to enable the new behavior instead of reinstalling the addon.
 
 We will create an upgrade step that:
 
 * runs the typeinfo step (i.e. loads the GenericSetup configuration stored in ``profiles/default/types.xml`` and ``profiles/default/types/...`` so we don't have to reinstall the add-on to have our changes from above take effect) and
-* cleans up the talks that might be scattered around the site in the early stages of creating it. We will move all talks to a folder ``talks`` (unless they already are there).
+* cleans up the talks that might be scattered around the site in the early stages of creating it.
+  We will move all talks to a folder ``talks`` (unless they already are there).
 
-Upgrade steps can be registered in their own ZCML file to prevent cluttering the main :file:`configure.zcml`. Include a new :file:`upgrades.zcml` in our :file:`configure.zcml` by adding:
+Upgrade steps can be registered in their own ZCML file to prevent cluttering the main :file:`configure.zcml`.
+Include a new :file:`upgrades.zcml` in our :file:`configure.zcml` by adding:
 
 ..  code-block:: xml
 
@@ -176,13 +190,16 @@ Create :file:`upgrades.zcml`:
 
     </configure>
 
-The upgrade step bumps the version number of the GenericSetup profile of :py:mod:`ploneconf.site` from 1000 to 1001. The version is stored in :file:`profiles/default/metadata.xml`. Change it to
+The upgrade step bumps the version number of the GenericSetup profile of :py:mod:`ploneconf.site` from 1000 to 1001.
+The version is stored in :file:`profiles/default/metadata.xml`.
+Change it to
 
 ..  code-block:: xml
 
     <version>1001</version>
 
-GenericSetup now expects the code as a method :py:meth:`upgrade_site` in the file :file:`upgrades.py`. Let's create it.
+GenericSetup now expects the code as a method :py:meth:`upgrade_site` in the file :file:`upgrades.py`.
+Let's create it.
 
 ..  code-block:: python
     :linenos:
@@ -265,7 +282,8 @@ Alternatively you also select which upgrade steps to run like this:
 
 .. note::
 
-    Upgrading from an older version of Plone to a newer one also runs upgrade steps from the package :py:mod:`plone.app.upgrade`. You should be able to upgrade a clean site from 2.5 to 5.0 with one click.
+    Upgrading from an older version of Plone to a newer one also runs upgrade steps from the package :py:mod:`plone.app.upgrade`.
+    You should be able to upgrade a clean site from 2.5 to 5.0 with one click.
 
     For an example see the upgrade-step to Plone 5.0a1 https://github.com/plone/plone.app.upgrade/blob/master/plone/app/upgrade/v50/alphas.py#L37
 
@@ -276,7 +294,8 @@ Alternatively you also select which upgrade steps to run like this:
 Add a browserlayer
 ------------------
 
-A browserlayer is another such marker interface. Browserlayers allow us to easily enable and disable views and other site functionality based on installed add-ons and themes.
+A browserlayer is another such marker interface, but this time on the request.
+Browserlayers allow us to easily enable and disable views and other site functionality based on installed add-ons and themes.
 
 Since we want the features we write only to be available when :py:mod:`ploneconf.site` actually is installed we can bind them to a browserlayer.
 
@@ -313,7 +332,8 @@ It is enabled by GenericSetup when installing the package since it is registered
           />
     </layers>
 
-We should bind all views to it. Here is an example using the talkview.
+We should bind all views to it.
+Here is an example using the talkview.
 
 ..  code-block:: xml
     :emphasize-lines: 4
@@ -327,7 +347,8 @@ We should bind all views to it. Here is an example using the talkview.
         permission="zope2.View"
         />
 
-Note the relative Python path :py:class:`..interfaces.IPloneconfSiteLayer`. It is equivalent to the absolute path :py:class:`ploneconf.site.interfaces.IPloneconfSiteLayer`.
+Note the relative Python path :py:class:`..interfaces.IPloneconfSiteLayer`.
+It is equivalent to the absolute path :py:class:`ploneconf.site.interfaces.IPloneconfSiteLayer`.
 
 .. seealso::
 
@@ -350,7 +371,8 @@ Add catalog indexes
 -------------------
 
 In the ``talklistview`` we had to wake up all objects to access some of their attributes.
-That is OK if we don't have many objects and they are light dexterity objects. If we had thousands of objects this might not be a good idea.
+That is OK if we don't have many objects and they are light dexterity objects.
+If we had thousands of objects this might not be a good idea.
 
 Instead of loading them all into memory we will use catalog indexes to get the data we want to display.
 
@@ -390,7 +412,10 @@ The ``column ..`` entries allow us to display the values of these indexes in the
 
 .. note::
 
-    The new indexes are still empty. We'll have to reindex them. To do so by hand go to http://localhost:8080/Plone/portal_catalog/manage_catalogIndexes, select the new indexes and click :guilabel:`Reindex`. We could also rebuild the whole catalog by going to the :guilabel:`advanced`-tab and clicking :guilabel:`Clear and Rebuild`. For large sites that can take a long time.
+    The new indexes are still empty. We'll have to reindex them.
+    To do so by hand go to http://localhost:8080/Plone/portal_catalog/manage_catalogIndexes, select the new indexes and click :guilabel:`Reindex`.
+    We could also rebuild the whole catalog by going to the :guilabel:`advanced`-tab and clicking :guilabel:`Clear and Rebuild`.
+    For large sites that can take a long time.
 
     We could also write an upgrade step to enable the catalog-indexes and reindex all talks:
 
@@ -422,7 +447,8 @@ The new indexes behave like the ones that Plone has already built in:
     >>> (Pdb) brain.speaker
     u'David Glick'
 
-We now can use the new indexes to improve the talklistview so we don't have to *wake up* the objects any more. Instead we use the brains' new attributes.
+We now can use the new indexes to improve the talklistview so we don't have to *wake up* the objects any more.
+Instead we use the brains' new attributes.
 
 .. code-block:: python
     :linenos:
@@ -447,7 +473,8 @@ We now can use the new indexes to improve the talklistview so we don't have to *
                     })
             return results
 
-The template does not need to be changed and the result in the browser did not change, either. But when listing a large number of objects the site will now be faster since all the data you use comes from the catalog and the objects do not have to be loaded into memory.
+The template does not need to be changed and the result in the browser did not change, either.
+But when listing a large number of objects the site will now be faster since all the data you use comes from the catalog and the objects do not have to be loaded into memory.
 
 
 .. _dexterity2-use_indexes-label:
@@ -532,7 +559,8 @@ Modify :py:class:`TalkListView` to return only brains and adapt the template to 
 Add collection criteria
 -----------------------
 
-To be able to search content in collections using these new indexes we would have to register them as criteria for the querystring widget that collections use. As with all features make sure you only do this if you really need it!
+To be able to search content in collections using these new indexes we would have to register them as criteria for the querystring widget that collections use.
+s with all features make sure you only do this if you really need it!
 
 
 Add a new file :file:`profiles/default/registry.xml`
@@ -618,7 +646,8 @@ Add new file :file:`profiles/default/diff_tool.xml`
       </difftypes>
     </object>
 
-Finally you need to activate the versioning behavior on the content type. Edit :file:`profiles/default/types/talk.xml`:
+Finally you need to activate the versioning behavior on the content type.
+Edit :file:`profiles/default/types/talk.xml`:
 
 .. code-block:: xml
     :linenos:

--- a/mastering-plone/dexterity_2.rst
+++ b/mastering-plone/dexterity_2.rst
@@ -333,7 +333,7 @@ It is enabled by GenericSetup when installing the package since it is registered
     </layers>
 
 We should bind all views to it.
-Here is an example using the talkview.
+Here is an example using the ``talklistview``.
 
 ..  code-block:: xml
     :emphasize-lines: 4

--- a/mastering-plone/dexterity_2.rst
+++ b/mastering-plone/dexterity_2.rst
@@ -198,7 +198,7 @@ Change it to
 
     <version>1001</version>
 
-GenericSetup now expects the code as a method :py:meth:`upgrade_site` in the file :file:`upgrades.py`.
+``GenericSetup`` now expects the code as a method :py:meth:`upgrade_site` in the file :file:`upgrades.py`.
 Let's create it.
 
 ..  code-block:: python

--- a/mastering-plone/dexterity_2.rst
+++ b/mastering-plone/dexterity_2.rst
@@ -412,7 +412,8 @@ The ``column ..`` entries allow us to display the values of these indexes in the
 
 .. note::
 
-    The new indexes are still empty. We'll have to reindex them.
+    The new indexes are still empty.
+    We'll have to reindex them.
     To do so by hand go to http://localhost:8080/Plone/portal_catalog/manage_catalogIndexes, select the new indexes and click :guilabel:`Reindex`.
     We could also rebuild the whole catalog by going to the :guilabel:`advanced`-tab and clicking :guilabel:`Clear and Rebuild`.
     For large sites that can take a long time.

--- a/mastering-plone/dexterity_3.rst
+++ b/mastering-plone/dexterity_3.rst
@@ -303,8 +303,8 @@ Second we create the FTI for the new type in :file:`profiles/default/types/spons
      <property name="add_permission">cmf.AddPortalContent</property>
      <property name="klass">plone.dexterity.content.Container</property>
      <property name="behaviors">
-      <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-      <element value="plone.app.content.interfaces.INameFromTitle"/>
+      <element value="plone.dublincore"/>
+      <element value="plone.namefromtitle"/>
      </property>
      <property name="schema">ploneconf.site.content.sponsor.ISponsor</property>
      <property name="model_source"></property>
@@ -729,7 +729,7 @@ Do *not* use the :py:class:`IBasic` or :py:class:`IDublinCore` behavior to add t
          <property name="model_source"></property>
          <property name="model_file"></property>
          <property name="behaviors">
-          <element value="plone.app.content.interfaces.INameFromTitle"/>
+          <element value="plone.namefromtitle"/>
          </property>
          <property name="schema_policy">dexterity</property>
          <alias from="(Default)" to="(dynamic view)"/>

--- a/mastering-plone/embed.rst
+++ b/mastering-plone/embed.rst
@@ -90,9 +90,9 @@ To add the behavior to talks, we do this in :file:`profiles/default/types/talk.x
     :emphasize-lines: 4
 
     <property name="behaviors">
-      <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-      <element value="plone.app.content.interfaces.INameFromTitle"/>
-      <element value="starzel.votable_behavior.interfaces.IVoting"/>
+      <element value="plone.dublincore"/>
+      <element value="plone.namefromtitle"/>
+      <element value="starzel.voting"/>
     </property>
 
 ... only:: not presentation

--- a/mastering-plone/events.rst
+++ b/mastering-plone/events.rst
@@ -30,11 +30,11 @@ First enable the behavior :py:class:`IEventBasic` for talks in :file:`profiles/d
     :emphasize-lines: 6
 
     <property name="behaviors">
-      <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-      <element value="plone.app.content.interfaces.INameFromTitle"/>
-      <element value="ploneconf.site.behavior.social.ISocial"/>
-      <element value="ploneconf.site.interfaces.ITalk"/>
-      <element value="plone.app.event.dx.behaviors.IEventBasic"/>
+      <element value="plone.dublincore"/>
+      <element value="plone.namefromtitle"/>
+      <element value="ploneconf.social"/>
+      <element value="ploneconf.talk"/>
+      <element value="plone.eventbasic"/>
     </property>
 
 After you activate the behavior by hand or reinstalled the add-on you will now have some additional fields for ``start`` and ``end``.

--- a/mastering-plone/export_code.rst
+++ b/mastering-plone/export_code.rst
@@ -76,8 +76,8 @@ Upon installing, Plone reads the file :file:`profiles/default/types/talk.xml` an
      <property name="add_permission">cmf.AddPortalContent</property>
      <property name="klass">plone.dexterity.content.Container</property>
      <property name="behaviors">
-      <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-      <element value="plone.app.content.interfaces.INameFromTitle"/>
+      <element value="plone.dublincore"/>
+      <element value="plone.namefromtitle"/>
      </property>
      <property name="schema"></property>
      <property

--- a/mastering-plone/export_code.rst
+++ b/mastering-plone/export_code.rst
@@ -157,7 +157,7 @@ Now our package has new configuration for Generic Setup. Generic Setup store the
 
 The escaped inline xml is simply too ugly to look at. You should move it to a separate file!
 
-Create a new folder :file:`content` in the main directory (from the buildout directory perspective that is :file:`src/ploneconf.site/src/ploneconf/site/content/`). Inside add an empty file :file:`__init__.py` and a file :file:`talk.xml` that contains the real XML (copied from http://localhost:8080/Plone/dexterity-types/talk/@@modeleditor and beautified with some online XML formatter (http://lmgtfy.com/?q=xml+formatter))
+Create a new folder :file:`content` in the main directory (from the buildout directory perspective that is :file:`src/ploneconf.site/src/ploneconf/site/content/`). Inside add an empty file :file:`__init__.py` and a file :file:`talk.xml` that contains the real XML (copied from http://localhost:8080/Plone/dexterity-types/talk/@@modeleditor and beautified with some online XML formatter (http://google.com/?q=xml+formatter))
 
 ..  code-block:: xml
     :linenos:


### PR DESCRIPTION
- Minor fixes, like using implementer and provider decorators
- Use behavior shortnames as best practice.
- Refine misleading explanation of IFormFieldProvider