### PR TITLE
Volto hands on: Missing import and changed arguments of openObjectBrowser

### DIFF
--- a/voltohandson/blocksedit.rst
+++ b/voltohandson/blocksedit.rst
@@ -166,7 +166,7 @@ We will start this time with the `Edit.jsx` component. We'll be creating two chi
                         href: '',
                       });
                     }
-                  : () => openObjectBrowser('link')
+                  : () => openObjectBrowser({ mode: 'link' })
               }
               onChange={(name, value) => {
                 onChangeTile(tile, {

--- a/voltohandson/contenttypesviews.rst
+++ b/voltohandson/contenttypesviews.rst
@@ -18,7 +18,7 @@ Creating a view for a custom content type
 
 Create a new file in ``src/components/Views/SuccessStory.jsx``. Let's start simple:
 
-.. code-block:: jsx
+.. code-block:: jsx    
 
     import React from 'react';
 
@@ -31,14 +31,17 @@ Create a new file in ``src/components/Views/SuccessStory.jsx``. Let's start simp
 Then add to the configuration object:
 
 .. code-block:: js
-   :emphasize-lines: 3-6
-
+   
+    import SuccessStory from "@package/components/Views/SuccessStory";
+    
+    ...
+    
     export const views = {
       ...defaultViews,
       contentTypesViews: {
         ...defaultViews.contentTypesViews,
-        success_story: SuccessStory,
-      },
+        success_story: SuccessStory
+      }
     };
 
 Create a new ``Success Story`` content type, fill the title and save. Your custom view should be in place.


### PR DESCRIPTION
I did the trainiing with Volto 4 alpha 18
So https://github.com/plone/training/commit/73b91ad0c52adb07c6e441a712530f4997d3ba36 needs to be checked for Volto 4 final.