### PR TITLE
Change from {doc}`glossary` to {ref}`glossary-label` because it was l…

### DIFF
--- a/docs/contributing/writing-docs-guide.md
+++ b/docs/contributing/writing-docs-guide.md
@@ -214,7 +214,7 @@ This is MyST syntax for term ``{term}`React` ``
 
 ##### Glossary terms
 
-Add a term to the {doc}`glossary`, located at {file}`/glossary.md`.
+Add a term to the {ref}`glossary-label`, located at {file}`/glossary.md`.
 
 ```md
 React
@@ -222,7 +222,7 @@ React
     Volto, the frontend for Plone 6, uses React.
 ```
 
-Reference a term in the {doc}`glossary`.
+Reference a term in the {ref}`glossary-label`.
 
 ```md
 Using {term}`React` makes frontends fun again!

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,6 +6,8 @@ html_meta:
   "keywords": "Plone, training, glossary, term, definition"
 ---
 
+(glossary-label)=
+
 # Glossary
 
 ```{glossary}


### PR DESCRIPTION
…inking to the official Python 3 docs.