### PR TITLE
node 16 is unsupported

### DIFF
--- a/docs/volto/bootstrap.md
+++ b/docs/volto/bootstrap.md
@@ -35,7 +35,8 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
 Then you can install the latest LTS version of node:
 
 ```shell
-nvm install --lts
+nvm install lts/fermium
+nvm use lts/fermium
 ```
 
 We use the package manager {file}`yarn`, to install do:


### PR DESCRIPTION
```
$ yarn start
yarn run v1.22.15
error volto-starter-kit@8.4.0: The engine "node" is incompatible with this module. Expected version "^10 || ^12 || ^14". Got "16.13.0"
error Commands cannot run with an incompatible environment.
```