### PR TITLE
Separate test jobs in GitHub Actions

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -22,8 +22,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -q -r requirements.txt -c constraints.txt
 
-      - name: Run tests with make test
-        run: make testlight
+      - name: Run spellcheck
+        run: make spellcheck
+
+#      # temporarily comment out per @kseuss.
+#      - name: Run linkcheck
+#        run: make linkcheck
 
       - name: Prepare deploy
         run: make deploy

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -25,9 +25,8 @@ jobs:
       - name: Run spellcheck
         run: make spellcheck
 
-#      # temporarily comment out per @kseuss.
-#      - name: Run linkcheck
-#        run: make linkcheck
+      - name: Run linkcheck
+        run: make linkcheck
 
       - name: Prepare deploy
         run: make deploy

--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,6 @@ doctest:
 .PHONY: test
 test: clean linkcheck spellcheck  ## Run linkcheck, spellcheck
 
-.PHONY: test
-testlight: clean spellcheck  ## Run spellcheck
-
 .PHONY: deploy
 deploy: clean html
 

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ linkcheck: ## Run linkcheck
 
 .PHONY: linkcheckbroken
 linkcheckbroken: ## Run linkcheck and show only broken links
-	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck | GREP_COLORS='0;31' egrep -wi broken --color=auto
+	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck | GREP_COLORS='0;31' grep -wi "broken\|redirect" --color=auto
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 		"or in $(BUILDDIR)/linkcheck/ ."

--- a/docs/mastering-plone/upgrade_steps.md
+++ b/docs/mastering-plone/upgrade_steps.md
@@ -221,7 +221,7 @@ Alternatively you also select which upgrade steps to run like this:
 Upgrading from an older version of Plone to a newer one also runs upgrade steps from the package {py:mod}`plone.app.upgrade`.
 You should be able to upgrade a clean site from 2.5 to 5.0 with one click.
 
-Find the upgrade steps in  <https://github.com/plone/plone.app.upgrade/blob/master/plone/app/upgrade/>
+Find the upgrade steps in <https://github.com/plone/plone.app.upgrade/tree/master/plone/app/upgrade>
 ```
 
 (upgrade-steps-browserlayer-label)=

--- a/docs/voltohandson/requirements.md
+++ b/docs/voltohandson/requirements.md
@@ -37,5 +37,5 @@ We'll leave these tasks for later:
 
 ## Training ressources and assets
 
-There are a few files, mostly images, that you will need to recreate for the plone.org page.
+There are a few files, mostly images, that you will need to recreate for the `plone.org` page.
 They are currently available from this [Google Drive folder](https://drive.google.com/drive/folders/1xDleXE8Emhr9xn_pnZaGfO9_HmU31L9e?usp=sharing).


### PR DESCRIPTION
See #574.

This PR implements a more clear way to run the spellcheck and linkcheck tests in different steps, and indicates that linkcheck is temporarily disabled for build and deploy only.

It also fixes a couple of broken links and fixes a duplicate `.PHONY test` target.