### PR TITLE
Use linkcheckbroken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ linkcheck: bin/python  ## Run linkcheck
 
 .PHONY: linkcheckbroken
 linkcheckbroken: bin/python  ## Run linkcheck and show only broken links
-	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck | GREP_COLORS='0;31' grep -wi "broken\|redirect" --color=auto
+	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck | GREP_COLORS='0;31' grep -wi "broken\|redirect" --color=auto || test $$? = 1
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 		"or in $(BUILDDIR)/linkcheck/ ."
@@ -191,7 +191,7 @@ doctest: bin/python
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 .PHONY: test
-test: clean linkcheck spellcheck  ## Run linkcheck, spellcheck
+test: clean linkcheckbroken spellcheck  ## Run linkcheckbroken, spellcheck
 
 .PHONY: deploy
 deploy: clean html

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -75,7 +75,7 @@ CloudFormation
 
 Travis CI
     Travis CI is a hosted, distributed continuous integration service used to build and test software projects hosted at GitHub.
-    Open source projects may be tested with limited runs via [travis-ci.org](https://travis-ci.org).
+    Open source projects may be tested with limited runs via [travis-ci.com](https://www.travis-ci.com/).
 
 Solr
     [Solr](https://solr.apache.org/) is a popular, blazing-fast, open source enterprise search platform built on Apache Lucene.

--- a/docs/mastering-plone-5/api.md
+++ b/docs/mastering-plone-5/api.md
@@ -171,7 +171,7 @@ A video of the talk [Debug like a pro. How to become a better programmer through
 - Only managers should be able to use the view (the permission is called **cmf.ManagePortal**).
 - Reload the frontpage after calling the view.
 - Display a message about the results (<https://docs.plone.org/develop/plone.api/docs/portal.html#show-notification-message>).
-- For extra credits use the library [requests](https://requests.readthedocs.io/) and [icndb](http://www.icndb.com/api/) to populate the talks with jokes.
+- For extra credits use the library [requests](https://requests.readthedocs.io/en/latest/) and [icndb](http://www.icndb.com/api/) to populate the talks with jokes.
 - Use the utility methods `cropText` from `Producs.CMFPlone.browser.ploneview.Plone` to crop the title after 20 characters.
 
 ```{note}

--- a/docs/mastering-plone/api.md
+++ b/docs/mastering-plone/api.md
@@ -179,7 +179,7 @@ A video of the talk [Debug like a pro. How to become a better programmer through
 - Only managers should be able to use the view (the permission is called **cmf.ManagePortal**).
 - Reload the frontpage after calling the view.
 - Display a message about the results (<https://docs.plone.org/develop/plone.api/docs/portal.html#show-notification-message>).
-- For extra credits use the library [requests](https://requests.readthedocs.io/) and [icndb](http://www.icndb.com/api/) to populate the talks with jokes.
+- For extra credits use the library [requests](https://requests.readthedocs.io/en/latest/) and [icndb](http://www.icndb.com/api/) to populate the talks with jokes.
 - Use the utility methods `cropText` from `Producs.CMFPlone.browser.ploneview.Plone` to crop the title after 20 characters.
 
 ```{note}

--- a/docs/testing/continuous_integration.md
+++ b/docs/testing/continuous_integration.md
@@ -49,7 +49,7 @@ Let's see how to enable our testing package on Travis.
 
 First, we need to create a repository on GitHub. We don't need to push code to it yet.
 
-Then we need a Travis CI account: go to [https://travis-ci.org](https://travis-ci.org) and signup with your GitHub credentials.
+Then we need a Travis CI account: go to https://www.travis-ci.com/ and signup with your GitHub credentials.
 
 If we go to the settings control panel, we can see a list of organizations and repositories for which we can enable Travis.
 We could also see our newly created repository and we can enable it.

--- a/docs/voltohandson/header.md
+++ b/docs/voltohandson/header.md
@@ -81,7 +81,7 @@ Then we adjust the margin for the homepage:
 
 ## Logo
 
-We use [component shadowing](#component-shadowing) to customize (and override) Volto original components.
+We use [component shadowing](header-component-shadowing-label) to customize (and override) Volto original components.
 Get the Plone logo (`Logo.svg`) from the `training-resources` you downloaded from the [google drive](https://drive.google.com/drive/folders/1xDleXE8Emhr9xn_pnZaGfO9_HmU31L9e?usp=sharing).
 
 ```{note}
@@ -103,7 +103,7 @@ We have to make some more changes to that component, such as removing the search
 
 This will be the outcome:
 
-```js
+```jsx
 import { Logo, Navigation } from '@plone/volto/components';
 
 ...
@@ -125,6 +125,8 @@ render() {
     );
   }
 ```
+
+(header-component-shadowing-label)=
 
 ## Component shadowing
 


### PR DESCRIPTION
- Use linkcheckbroken instead of linkcheck for a concise output.

See https://github.com/plone/training/pull/626#issuecomment-1179532828