### PR TITLE
Minor edit to Plone Deployment sections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,9 @@ This changelog is only very rough. For the full changelog please refer to https:
 
 - Review solr docs [gforcada]
 
+- Add steps to Plone Deployment regarding images release on GitHub,
+  and URL to visit locally deployed site  [danalvrz]
+
 1.2.4 (2014-10-03)
 ------------------
 

--- a/docs/plone-deployment/deploy.md
+++ b/docs/plone-deployment/deploy.md
@@ -32,13 +32,15 @@ Also use this command when there is a new version of any of the images.
 make status
 ```
 
+Once everything is running, and if your deployment was local (with Vagrant), you will be able to visit your website at `https://plone-conference.localhost`.
+
 ### Check Logs
 
-|Tool|Command|
-|-|-|
-|webserver|`make logs-webserver`|
-|frontend|`make logs-frontend`|
-|backend|`make logs-backend`|
+| Tool      | Command               |
+| --------- | --------------------- |
+| webserver | `make logs-webserver` |
+| frontend  | `make logs-frontend`  |
+| backend   | `make logs-backend`   |
 
 ## Continuous Integration
 

--- a/docs/plone-deployment/deploy.md
+++ b/docs/plone-deployment/deploy.md
@@ -36,11 +36,11 @@ Once everything is running, and if your deployment was local (with Vagrant), you
 
 ### Check Logs
 
-| Tool      | Command               |
-| --------- | --------------------- |
-| webserver | `make logs-webserver` |
-| frontend  | `make logs-frontend`  |
-| backend   | `make logs-backend`   |
+|Tool|Command|
+|-|-|
+|webserver|`make logs-webserver`|
+|frontend|`make logs-frontend`|
+|backend|`make logs-backend`|
 
 ## Continuous Integration
 

--- a/docs/plone-deployment/new-project.md
+++ b/docs/plone-deployment/new-project.md
@@ -9,6 +9,9 @@ myst:
 
 # Create a Project
 
+As mentioned in the {doc}`intro`'s Training Choices, for this Training, GitHub is a requirement to build the Docker images automatically.
+The steps in this training may be adapted to other providers, including GitLab.
+
 ## Generating the Codebase
 
 Run `cookiecutter` to create a Plone project skeleton using the Cookiecutter {term}`cookiecutter-plone-starter` with the following command.
@@ -142,17 +145,9 @@ When the process completes successfully, it will exit with a message similar to 
 ✨  Done in 98.97s.
 ```
 
-Remember, having the repository on GitHub is currently a requirement to build the Docker images automatically; this might be a good moment to do so in case you had not yet.
-
-The same could be done with other options like GitLab, but we do not provide a working example for it at the moment.
-
 ````{note}
 Due to an output difference when translations are built by the `@plone/generator-volto`, at the moment, it is necessary to run on the root directory:
 
-```{code-block} shell
+```shell
 make i18n
 ````
-
-```
-
-```

--- a/docs/plone-deployment/new-project.md
+++ b/docs/plone-deployment/new-project.md
@@ -151,3 +151,4 @@ Due to an output difference when translations are built by the `@plone/generator
 ```shell
 make i18n
 ````
+````

--- a/docs/plone-deployment/new-project.md
+++ b/docs/plone-deployment/new-project.md
@@ -150,5 +150,5 @@ Due to an output difference when translations are built by the `@plone/generator
 
 ```shell
 make i18n
-````
+```
 ````

--- a/docs/plone-deployment/new-project.md
+++ b/docs/plone-deployment/new-project.md
@@ -23,9 +23,9 @@ You can accept the default values in square brackets (`[default-option]`) by hit
 
 For this training, we recommend you to provide:
 
-* `project_title`: **Plone Conference**
-* `github_organization`: Your GitHub username
-* `container_registry`: **2**
+- `project_title`: **Plone Conference**
+- `github_organization`: Your GitHub username
+- `container_registry`: **2**
 
 ```{code-block} console
 :emphasize-lines: 1,15,19
@@ -123,7 +123,6 @@ To install both the Plone backend and frontend, use the following command.
 make install
 ```
 
-
 This will take a few minutes.
 ☕️
 First the backend, then the frontend will be installed.
@@ -141,4 +140,19 @@ When the process completes successfully, it will exit with a message similar to 
 
 ```console
 ✨  Done in 98.97s.
+```
+
+Remember, having the repository on GitHub is currently a requirement to build the Docker images automatically; this might be a good moment to do so in case you had not yet.
+
+The same could be done with other options like GitLab, but we do not provide a working example for it at the moment.
+
+````{note}
+Due to an output difference when translations are built by the `@plone/generator-volto`, at the moment, it is necessary to run on the root directory:
+
+```{code-block} shell
+make i18n
+````
+
+```
+
 ```


### PR DESCRIPTION
- Add comment reminding user to have the repository on GitHub, so Docker images can be automatically generated.
- Add note about a `make` command needed due to a Volto generator unexpected behavior.
- Add comment about how to visit site once deployed locally.