### PR TITLE
Fixed a typo in 9.8. Default content types > Link

### DIFF
--- a/docs/mastering-plone/features.md
+++ b/docs/mastering-plone/features.md
@@ -423,7 +423,7 @@ Event
 
 Link
 
-: A link to an internal oder external target.
+: A link to an internal or external target.
 
   ```{figure} _static/features_add_a_link.png
   ```


### PR DESCRIPTION
Fixed a typo in 9.8. Default content types > Link where 'oder' was written instead of `or`