### PR TITLE
Changed reapeating Mail to Url Management in 11.1.1 General, Control panels list

### DIFF
--- a/docs/mastering-plone/configuring_customizing.md
+++ b/docs/mastering-plone/configuring_customizing.md
@@ -51,12 +51,12 @@ Other control panels, e.g. Content Rules still need to be implemented.
 1. Date and Time
 1. Language
 1. Mail
-1. Url Management
 1. Navigation
 1. Search
 1. Site
 1. Social Media
 1. Undo
+1. URL Management
 1. Volto Settings
 
 The following control panels are so far only available in the backend:

--- a/docs/mastering-plone/configuring_customizing.md
+++ b/docs/mastering-plone/configuring_customizing.md
@@ -51,7 +51,7 @@ Other control panels, e.g. Content Rules still need to be implemented.
 1. Date and Time
 1. Language
 1. Mail
-1. Mail
+1. Url Management
 1. Navigation
 1. Search
 1. Site


### PR DESCRIPTION
In page:
[Mastering Plone 6 Development > 11. Configuring and Customizing Plone "Through The Web" > 11.1. The Control Panel > 11.1.1. General](https://training.plone.org/mastering-plone/configuring_customizing.html#general)

In the control panels list, changed the repeating **Mail** to **Url Management**