### PR TITLE
Added the missing command

### DIFF
--- a/docs/volto/bootstrap.md
+++ b/docs/volto/bootstrap.md
@@ -110,6 +110,7 @@ To run the project you can type:
 
 ```shell
 cd my-volto-app
+yarn install
 yarn start
 ```
 


### PR DESCRIPTION
Added the missing `yarn install` command in the volto training docs Closes #714