### PR TITLE
Removed unnecessary anchor tag in code block in volto_talkview.md...#718

### DIFF
--- a/docs/mastering-plone/volto_talkview.md
+++ b/docs/mastering-plone/volto_talkview.md
@@ -252,7 +252,6 @@ const TalkView = (props) => {
       <Segment clearing>
         {content.speaker && <Header dividing>{content.speaker}</Header>}
         <p>{content.company || content.website}</p>
-        <a href={`mailto:${content.email}`}>
         {content.email && (
           <p>
             Email: <a href={`mailto:${content.email}`}>{content.email}</a>


### PR DESCRIPTION
Removed unnecessary anchor tag <a href={`mailto:${content.email}`}> on the page [Mastering Plone 6 development > 22. Volto View Component: A Default View for a "Talk"](https://training.plone.org/mastering-plone/volto_talkview.html)  in the block where speaker email is added.