### PR TITLE
Fixed the typo

### DIFF
--- a/docs/voltohandson/requirements.md
+++ b/docs/voltohandson/requirements.md
@@ -12,7 +12,7 @@ myst:
 # Project requirements
 
 Our hands-on exercise is to recreate the current iteration of [plone.org](https://plone.org) or rather a set of parts of the site that are suited different ways you can use volto.
-The screenshot below shows the current (2022 just before Plone conf) frontpage of `plone.org`. The red markings indicate the different sections of the website that we will be creating or customizing includong the header, navigation, highlight element, downlodad teaser and news listing:
+The screenshot below shows the current (2022 just before Plone conf) frontpage of `plone.org`. The red markings indicate the different sections of the website that we will be creating or customizing including the header, navigation, highlight element, downlodad teaser and news listing:
 
 ```{image} _static/ploneorg-frontpage.png
 :align: center


### PR DESCRIPTION
At [Project requirements](https://training.plone.org/voltohandson/requirements.html#project-requirements) there is a typo. It is written "includong" it should have been "including"

Closes #724 