### PR TITLE
Update links in preparation for 2022 archive

### DIFF
--- a/docs/mastering-plone-5/behaviors_2.md
+++ b/docs/mastering-plone-5/behaviors_2.md
@@ -443,7 +443,7 @@ You will also have to write a 'request' dummy that mocks the `getClientAddr` and
 :class: toggle
 
 There are no tests for `starzel.votablebehavior` at all at the moment.
-But you can refer to [chapter 24 (Testing in Plone)](https://training.plone.org/5/mastering-plone-5/testing.html) for how to setup unit testing for a package.
+But you can refer to [chapter 24 (Testing in Plone)](https://training.plone.org/mastering-plone-5/testing.html) for how to setup unit testing for a package.
 Put the particular test for this exercise into a file named {file}`starzel.votable_behavior/starzel/votable_behavior/tests/test_voting`.
 Remember you need an empty {file}`__init__.py` file in the {file}`tests` directory to make testing work.
 You also need to add `starzel.votable_behavior` to `test-eggs` in {file}`buildout.cfg` and re-run buildout.

--- a/docs/mastering-plone-5/deployment_sites.md
+++ b/docs/mastering-plone-5/deployment_sites.md
@@ -71,7 +71,7 @@ Deploying Plone and production-setups are outside the scope for this training.
 
 ```{seealso}
 - <https://5.docs.plone.org/manage/deploying/index.html>
-- <https://training.plone.org/5/deployment>
+- <https://2022.training.plone.org/deployment>
 ```
 
 (plone5-deployment-tools-label)=

--- a/docs/mastering-plone-5/intro.md
+++ b/docs/mastering-plone-5/intro.md
@@ -160,7 +160,7 @@ and then re-read it again while actually doing a complex project.
 
 ## Documentation
 
-Follow the training at <https://training.plone.org/5>
+Follow the training at <https://training.plone.org/mastering-plone-5/index.html>
 
 ```{note}
 You can use this presentation to copy & paste the code but you will memorize more if you type yourself.

--- a/docs/mastering-plone-5/resources.md
+++ b/docs/mastering-plone-5/resources.md
@@ -114,4 +114,4 @@ Open the file {file}`profiles/default/registry.xml` and add the following:
 The resources that are part of the registered bundle will now be deployed with every request.
 
 For more information on working with CSS and JavaScript resources, please see the [resource registry documentation](https://5.docs.plone.org/adapt-and-extend/theming/resourceregistry.html)
-or the [Advanced Diazo training class](https://training.plone.org/5/theming_plone_5/adv-diazo.html).
+or the [Advanced Diazo training class](https://2022.training.plone.org/theming_plone_5/adv-diazo.html).

--- a/docs/mastering-plone/theming.md
+++ b/docs/mastering-plone/theming.md
@@ -124,4 +124,4 @@ The resources that are part of the registered bundle will now be deployed with e
 
 % This chapter will be removed. No need to update the url to /theming_plone_5
 For more information on working with CSS and JavaScript resources, please see the [resource registry documentation](https://5.docs.plone.org/adapt-and-extend/theming/resourceregistry.html)
-or the [Advanced Diazo training class](https://training.plone.org/5/theming_plone_5/adv-diazo.html).
+or the [Advanced Diazo training class](https://2022.training.plone.org/theming_plone_5/adv-diazo.html).

--- a/docs/ttw/workflow.md
+++ b/docs/ttw/workflow.md
@@ -1247,9 +1247,9 @@ Martin Aspeli's famed "DCWorkflow's Hidden Gems" blog post: <https://web.archive
 
 Page templates: <https://5.docs.plone.org/adapt-and-extend/theming/templates_css/template_basics.html#id1>
 
-Plone developer training: <https://training.plone.org/5/mastering-plone/index.html>
+Plone developer training: <https://training.plone.org/mastering-plone/index.html>
 
-Existing workflow training class: <https://training.plone.org/5/workflow/index.html> (it’s more developer oriented)
+Existing workflow training class: <https://training.plone.org/workflow/index.html> (it’s more developer oriented)
 
 Alternative tools for building forms in Plone:
 

--- a/docs/wsgi/setup.md
+++ b/docs/wsgi/setup.md
@@ -13,10 +13,10 @@ myst:
 
 ## Installing Prerequisites
 
-Please follow the instructions given [here](https://training.plone.org/5/plone_training_config/instructions_plone5.html) to install a Ubuntu 18.04 box for this training.
+Please follow the instructions given [here](https://training.plone.org/plone_training_config/instructions_plone5.html) to install a Ubuntu 18.04 box for this training.
 This training is about deploying Plone, so we will not need the Plone instance provided by these instructions.
-If you follow the section on how to [Installing Plone without vagrant](https://training.plone.org/5/plone_training_config/instructions_plone5.html#installing-plone-without-vagrant), you can therefore stop following the instructions where it reads "Set up Plone for the training like this if you use your own OS (Linux or Mac)".
-If instead you have chosen to [Install Plone with Vagrant](https://training.plone.org/5/plone_training_config/instructions_plone5.html#installing-plone-with-vagrant), you can comment out the `# install plone` section in the `Vagrantfile`:
+If you follow the section on how to [Installing Plone without vagrant](https://training.plone.org/plone_training_config/instructions_plone5.html#installing-plone-without-vagrant), you can therefore stop following the instructions where it reads "Set up Plone for the training like this if you use your own OS (Linux or Mac)".
+If instead you have chosen to [Install Plone with Vagrant](https://training.plone.org/plone_training_config/instructions_plone5.html#installing-plone-with-vagrant), you can comment out the `# install plone` section in the `Vagrantfile`:
 
 ```{code-block} bash
 :emphasize-lines: 9-12


### PR DESCRIPTION
Do not merge until the URL https://2022.training.plone.org/ is ready to deploy.

Although I have set this to "draft", it may be reviewed.

Refs:
- https://github.com/plone/training/issues/740
- https://github.com/plone/training/issues/672