### PR TITLE
Fix the content of sitemap.xml to use proper URLs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,7 +170,8 @@ html_extra_path = [
 ]
 
 # Used by sphinx_sitemap to generate a sitemap
-html_baseurl = "https://training.plone.org"
+html_baseurl = "https://training.plone.org/"
+# https://sphinx-sitemap.readthedocs.io/en/latest/advanced-configuration.html#customizing-the-url-scheme
 sitemap_url_scheme = "{link}"
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Currently https://training.plone.org/sitemap.xml contains entries for URLs such as: `<loc>https://training.plone.orgcontributing/authors.html</loc>`. Adding a trailing slash to the `html_baseurl` fixes this.