### PR TITLE
Fix mentioned filename extension

### DIFF
--- a/docs/theming/theme_diazo.md
+++ b/docs/theming/theme_diazo.md
@@ -707,9 +707,9 @@ For example if you install a JQuery library you will find all JavaScript and CSS
 
 ## Adjust the layout and manifest files
 
-We need to adjust a bit the `manifest.ini`, to reflect the layout structure of the Bootstrap theme we got.
+We need to adjust a bit the `manifest.cfg`, to reflect the layout structure of the Bootstrap theme we got.
 
-By default the `manifest.ini` will look like this:
+By default the `manifest.cfg` will look like this:
 
 ```ini
 [theme]


### PR DESCRIPTION
I'm going trough the `Plone 6 Classic UI Theming` and found this minor glitch 😄 

A general question though: which source is _leading_ regarding Classic UI theming? training.plone.org or docs.plone.org? 🤔 

Given that on the last Plone Conference this train was not given, I'm not sure what's more recent/maintained.

Thanks for all the work, I've gone through all points until here and I can only say that it's impressive the work on `plonecli`, `bobtemplates.plone`, `mrbob` and of course all the great work on Plone 6 🎉 🥳 🤩 