### PR TITLE
Remove regex from sphinx-copybutton config, now that linenos are excl…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -220,10 +220,6 @@ ogp_custom_meta_tags = [
     '<meta property="og:locale" content="en_US" />',
 ]
 
-# -- sphinx_copybutton -----------------------
-copybutton_prompt_text = r"^ {0,2}\d{1,3}"
-copybutton_prompt_is_regexp = True
-
 
 # -- sphinx.ext.todo -----------------------
 todo_include_todos = True  # Uncomment to show todos.


### PR DESCRIPTION
…uded by default

See https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies

See also https://github.com/plone/documentation/pull/1563