### PR TITLE
Spelling Error inside the training docs

### DIFF
--- a/docs/mastering-plone/features.md
+++ b/docs/mastering-plone/features.md
@@ -289,7 +289,7 @@ Event
 Image
 
 : Like file but png, jpeg or other image types.
-  The Image content typ has an image field.
+  The Image content type has an image field.
   Values of the image field are saved in multiple scales to be accessible easily when rendering.
 
   ```{figure} _static/features_add_a_image.png


### PR DESCRIPTION

### **Description**: spelling error ✅type ❌typ

I, Vivek Kumar, agree to have this contribution published under the Creative Commons 4.0 International License (CC BY 4.0), with attribution to the Plone Foundation.