### PR TITLE
Update dexterity_reference.md

### DIFF
--- a/docs/mastering-plone/dexterity_reference.md
+++ b/docs/mastering-plone/dexterity_reference.md
@@ -691,7 +691,7 @@ import datetime
 
 
 def future_date(value):
-    if value and not value.date() >= datetime.date.today():
+    if value and not value >= datetime.date.today():
         raise Invalid('Meeting date can not be before today.')
     return True
 


### PR DESCRIPTION
As written, this triggers a crash. 
`AttributeError: 'datetime.date' object has no attribute 'date'`

Since `value` is already a `datetime.date` object, you can't call `.date()` on it.