### PR TITLE
Fix Broken Links

### DIFF
--- a/docs/effective-volto/getting-started/project.md
+++ b/docs/effective-volto/getting-started/project.md
@@ -29,11 +29,11 @@ pip install cookiecutter
 
 ### nvm, Node.JS, Yeoman, and Yarn
 
-First install `nvm` and latest Node.JS according to the [Plone documentation](https://6.docs.plone.org/volto/getting-started/install.html#install-nvm-nodejs-version-manager).
+First install `nvm` and latest Node.JS according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#pre-requisites-for-installation).
 
-After that, install Yeoman according to the [Plone documentation](https://6.docs.plone.org/volto/getting-started/install.html#yeoman).
+After that, install Yeoman according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#pre-requisites-for-installation).
 
-Finally, install `yarn` according to the [Plone documentation](https://6.docs.plone.org/volto/getting-started/install.html#yarn-nodejs-package-manager).
+Finally, install `yarn` according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#pre-requisites-for-installation).
 
 ### Docker (optional, but recommended)
 

--- a/docs/effective-volto/getting-started/project.md
+++ b/docs/effective-volto/getting-started/project.md
@@ -31,7 +31,7 @@ pip install cookiecutter
 
 First install `nvm` and latest Node.JS according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#pre-requisites-for-installation).
 
-After that, install Yeoman according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#pre-requisites-for-installation).
+After that, install Yeoman according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#yeoman-and-the-volto-boilerplate-generator).
 
 Finally, install `yarn` according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#pre-requisites-for-installation).
 

--- a/docs/effective-volto/getting-started/project.md
+++ b/docs/effective-volto/getting-started/project.md
@@ -33,7 +33,7 @@ First install `nvm` and latest Node.JS according to the [Plone documentation](ht
 
 After that, install Yeoman according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#yeoman-and-the-volto-boilerplate-generator).
 
-Finally, install `yarn` according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#pre-requisites-for-installation).
+Finally, install `yarn` according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#yarn).
 
 ### Docker (optional, but recommended)
 

--- a/docs/effective-volto/getting-started/project.md
+++ b/docs/effective-volto/getting-started/project.md
@@ -29,7 +29,7 @@ pip install cookiecutter
 
 ### nvm, Node.JS, Yeoman, and Yarn
 
-First install `nvm` and latest Node.JS according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#pre-requisites-for-installation).
+First install `nvm` and latest Node.JS according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#nvm).
 
 After that, install Yeoman according to the [Plone documentation](https://6.docs.plone.org/install/create-project.html#yeoman-and-the-volto-boilerplate-generator).
 


### PR DESCRIPTION
Dead links for Plone Documentation. Updated with the ones from the [cookie-cutter-plone-starter](https://github.com/collective/cookiecutter-plone-starter?tab=readme-ov-file).


<img width="400" alt="Screenshot 2024-03-13 at 11 22 40 AM" src="https://github.com/plone/training/assets/25995514/61ba8192-14dd-4f3d-b27c-a6c01024123f">
