### PR TITLE
Linkcheck fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,36 +89,26 @@ pygments_style = "sphinx"
 # Options for the linkcheck builder
 # Ignore localhost
 linkcheck_ignore = [
-    r"http://localhost",
+    r"https?://.*localhost.*",
     r"http://0.0.0.0",
     r"http://127.0.0.1",
     r"http://example.com",
     r"https://github.com/plone/training/issues/new/choose",  # requires auth
     r"https://docs.github.com/en/get-started/.*",  # GitHub docs require auth
     r"https://github.com/plone/mockup/blob/master/mockup/.jshintrc",  # TODO: remove when javascript/development-process.md is updated. See https://github.com/plone/training/issues/611
-    r"https://www.packtpub.com/.*",  # test say 500 Server Error but manually they work
     r"https://www.dipf.de/.*",  # a timeout from time to time
-    r"https?://plone-conference.localhost.*",
+    r"https://www.linode.com/.*",  # test say 500 Server Error but manually they work
+    r"https://www.packtpub.com/.*",  # test say 500 Server Error but manually they work
     # ### Start of list of anchored links
     # Prior to each PloneConf, uncomment these lines to verify that the links work,
     # although the anchor cannot be found.
     # GitHub rewrites anchors with JavaScript.
     # See https://github.com/plone/training/issues/598#issuecomment-1105168109
-    "https://github.com/collective/awesome-volto#addons",
-    "https://github.com/collective/collective.easyform#collectivez3cformnorobots-support",
-    "https://github.com/collective/collective.easyform#recaptcha-support",
-    "https://github.com/plone/plone.app.contentlisting/#methods-of-contentlistingobjects",
-    "https://github.com/plone/plone.app.contenttypes#changing-the-base-class-for-existing-objects",
-    "https://plone.github.io/mockup/dev/#pattern/autotoc",
-    "https://plone.github.io/mockup/dev/#pattern/modal",
-    "https://plone.github.io/mockup/dev/#pattern/moment",
-    "https://github.com/collective/collective.exportimport#faq-tips-and-tricks",
-    "https://github.com/plone/plone.app.contenttypes/tree/2.2.x#migration",
+    # Ignore github.com pages with anchors
+    r"https://github.com/.*#.*",
+    r"https://plone.github.io/mockup/dev/.*#.*",
+    # Ignore other specific anchors
     "https://robotframework.org/SeleniumLibrary/SeleniumLibrary.html#Keywords",
-    "https://github.com/plone/plone.restapi/blob/afde2a940d2518e061eb3fe30093093af55e3a50/src/plone/restapi/services/content/configure.zcml#L15-L20",
-    "https://github.com/plone/plone.rest#cors",
-    "https://github.com/plone/plone.docker#for-basic-usage",
-    "https://github.com/nodejs/release#release-schedule",
     # ### End of list of anchored links
 ]
 linkcheck_allowed_redirects = {

--- a/docs/contributing/authors.md
+++ b/docs/contributing/authors.md
@@ -303,7 +303,7 @@ An [online demo of all lexers that Pygments supports](https://pygments.org/demo/
 You can also use the [`pygmentize`](https://pygments.org/docs/cmdline/) binary.
 
 When using the online lexer, if any red-bordered rectangles appear, then the lexer for Pygments interprets your snippet as not valid.
-You can search the [Pygments issue tracker](https://github.com/pygments/pygments/search) for possible solutions, or submit a pull request to enhance the lexer.
+You can search the [Pygments issue tracker](https://github.com/pygments/pygments/issues?q=) for possible solutions, or submit a pull request to enhance the lexer.
 
 
 ## Synchronize the Browser While Editing

--- a/docs/contributing/writing-docs-guide.md
+++ b/docs/contributing/writing-docs-guide.md
@@ -255,7 +255,7 @@ This will greatly improve the editing and maintenance of your documentation.
 ## General Documentation Writing References
 
 - [Write the Docs - Documentation Guide](https://www.writethedocs.org/guide/)
-- [A Guide to Em Dashes, En Dashes, and Hyphens](https://www.merriam-webster.com/words-at-play/em-dash-en-dash-how-to-use)
+- [A Guide to Em Dashes, En Dashes, and Hyphens](https://www.merriam-webster.com/grammar/em-dash-en-dash-how-to-use)
 
 
 ### English grammar, spelling, punctuation, and syntax

--- a/docs/effective-volto/addons/semanticui.md
+++ b/docs/effective-volto/addons/semanticui.md
@@ -46,7 +46,7 @@ path).
 
 Volto's theme is called Pastanaga. It's a typical Semantic-UI theme. For
 the new elements and components that don't exist in Semantic-UI, the Pastanaga
-theme uses the [extras](https://github.com/plone/volto/tree/master/theme/themes/pastanaga/extras) folder. The downside is that they aren't fully using the Semantic-UI theming engine.
+theme uses the [extras](https://github.com/plone/volto/tree/main/packages/volto/theme/themes/pastanaga/extras) folder. The downside is that they aren't fully using the Semantic-UI theming engine.
 
 The key to success in Volto theming is to understand how Semantic-UI's theming
 engine works and how to manipulate it. Reading the `theme.less` and

--- a/docs/effective-volto/deployment/docker.md
+++ b/docs/effective-volto/deployment/docker.md
@@ -16,7 +16,7 @@ It is recommended that you follow the best practices explained in the "Installin
 
 You'll find in the Volto repository a simple `docker-compose` example:
 
-https://github.com/plone/volto/blob/main/docker-compose.yml
+https://github.com/plone/volto/blob/main/packages/volto/docker-compose.yml
 
 ```shell
 docker-compose -f <following_snippet.yml> up

--- a/docs/effective-volto/development/criticalCSS.md
+++ b/docs/effective-volto/development/criticalCSS.md
@@ -43,9 +43,9 @@ npx @plone/critical-css-cli -h
 npx @plone/critical-css-cli https://example.com -o critical.css
 ```
 
-You can pass multiple URLs and screen dimmensions and the extracted CSS will be
+You can pass multiple URLs and screen dimensions and the extracted CSS will be
 optimized (duplicate rules will be eliminated, etc). See the [Advanced preset
-of cssnano](https://cssnano.co/docs/what-are-optimisations/) for details. One last
+of cssnano](https://cssnano.github.io/cssnano/docs/what-are-optimisations/) for details. One last
 optimization applied strips all `@import` declarations from the generated CSS.
 
 After that, copy this file to the `public/critical.css` path (configurable

--- a/docs/effective-volto/development/debugging.md
+++ b/docs/effective-volto/development/debugging.md
@@ -18,4 +18,4 @@ component hierarchy, inspect props, hooks, HOCs, etc.
 Redux Dev Tools allows you to observe the Redux actions and inspect the store
 state.
 
-You can add `debugger` lines in your code, to trigger breakpoints in the browser. To debug the server, you need to hook the [Chrome DevTools](https://nodejs.org/en/docs/guides/debugging-getting-started). Note that there's multiple threads hooked into the inspector (server, client, hotreload process), so you'll have to find the one that coresponds to the server.
+You can add `debugger` lines in your code, to trigger breakpoints in the browser. To debug the server, you need to hook the [Chrome DevTools](https://nodejs.org/docs/latest/api/debugger.html). Note that there's multiple threads hooked into the inspector (server, client, hotreload process), so you'll have to find the one that coresponds to the server.

--- a/docs/effective-volto/development/icons.md
+++ b/docs/effective-volto/development/icons.md
@@ -9,7 +9,7 @@ myst:
 
 # Icons
 
-Volto has a pre-defined set of SVG icons from the Pastanaga UI icon system. You can find them in the code repo in [here](https://github.com/plone/volto/tree/master/src/icons). They are also browseable in https://pastanaga.io/icons/.
+Volto has a pre-defined set of SVG icons from the Pastanaga UI icon system. You can find them in the code repo in [here](https://github.com/plone/volto/tree/main/packages/volto/src/icons). They are also browseable in https://pastanaga.io/icons/.
 
 The following example shows how to display one of these icons.
 

--- a/docs/effective-volto/testing/storybook.md
+++ b/docs/effective-volto/testing/storybook.md
@@ -57,8 +57,7 @@ export const Breadcrumb = injectIntl(({ children, ...args }) => {
 
 Notice the `<Wrapper>` component, which provides a minimal Volto "environment context" that to ensure that the deeply-integrated Volto components can function.
 
-To create a static build of your storybook (which you can publish to a static
-http server, for example github.io pages), you need to run:
+To create a static build of your storybook (where you can publish to a static http server, for example [GitHub pages](https://pages.github.com/)), you need to run:
 
 ```
 yarn build-storybook

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -58,9 +58,6 @@ S3
 NFS
     [Network File System](https://en.wikipedia.org/wiki/Network_File_System).
 
-Amazon Opsworks
-    [AWS OpsWorks](https://aws.amazon.com/opsworks/) is a configuration management service that uses Chef, an automation platform that treats server configurations as code.
-
 Ansible
     [Ansible](https://www.ansible.com/) is an open source automation platform.
     Ansible can help you with configuration management, application deployment, task automation.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -184,7 +184,7 @@ Transpilation
 ES6
 ECMAScript 6
     [ECMAScript 6 (ES6)](https://262.ecma-international.org/6.0/) is a scripting language specification on which [JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/JavaScript) is based.
-    [Ecma International](https://www.ecma-international.org/) is in charge of standardizing ECMAScript.
+    [Ecma International](https://ecma-international.org/) is in charge of standardizing ECMAScript.
 
 mrs-developer
     Also called "missdev", a tool similar to buildout's `mr.developer`.

--- a/docs/mastering-plone-5/about_mastering.md
+++ b/docs/mastering-plone-5/about_mastering.md
@@ -42,7 +42,7 @@ The Mastering Plone Training was so far held publicly at the following occasions
 - [Plone Conference 2015, Bucharest](https://2015.ploneconf.org/)
 - [March 2015, Munich](https://www.starzel.de/blog/mastering-plone-training-march-2015)
 - Plone Conference 2014, Bristol
-- [June 2014, Caracas](https://twitter.com/hellfish2/status/476906131970068480)
+- [June 2014, Caracas](https://x.com/hellfish2/status/476906131970068480)
 - [May 2014, Munich](https://www.starzel.de/blog/mastering-plone)
 - [PythonBrasil/Plone Conference 2013, Brasilia](http://2013.pythonbrasil.org.br/)
 - PyCon DE 2012, Leipzig

--- a/docs/mastering-plone-5/frontpage.md
+++ b/docs/mastering-plone-5/frontpage.md
@@ -287,7 +287,7 @@ When you browse to the [publish.twitter.com](https://publish.twitter.com/) and h
   </div>
 
   <div class="col-lg-6">
-    <a class="twitter-timeline" data-height="600" data-dnt="true" href="https://twitter.com/ploneconf?ref_src=twsrc%5Etfw">Tweets by ploneconf</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <a class="twitter-timeline" data-height="600" data-dnt="true" href="https://x.com/ploneconf?ref_src=twsrc%5Etfw">Tweets by ploneconf</a> <script async src="https://platform.x.com/widgets.js" charset="utf-8"></script>
   </div>
 
 </metal:content-core>

--- a/docs/mastering-plone/add-ons.md
+++ b/docs/mastering-plone/add-ons.md
@@ -46,8 +46,8 @@ For example an add-on that has the goal to provide a bookmarking feature depends
 Have a look at the curated lists of add-ons:  
 
 
-[backend add-ons](https://github.com/collective/awesome-plone#readme)  
-[frontend add-ons](https://github.com/collective/awesome-volto#readme)
+[backend add-ons](https://github.com/collective/awesome-plone/blob/main/README.md)  
+[frontend add-ons](https://github.com/collective/awesome-volto/blob/main/README.md)
 
 
 
@@ -62,7 +62,7 @@ Here are some tips.
 
 - Find candidates on PyPi, npm  or Github:
 
-  - curated list of [backend add-ons](https://github.com/collective/awesome-plone#readme)
+  - curated list of [backend add-ons](https://github.com/collective/awesome-plone/blob/main/README.md)
   - curated list of [frontend add-ons](https://github.com/collective/awesome-volto#readme)
   - Python packages on Pypi: <https://pypi.org/search/?c=Framework+%3A%3A+Plone>
   - Plone add-ons on Github: <https://github.com/collective>

--- a/docs/mastering-plone/events.md
+++ b/docs/mastering-plone/events.md
@@ -201,7 +201,7 @@ const TalkView = ({ content }) => {
           )}
           {content.twitter && (
             <p>
-              <a href={`https://twitter.com/${content.twitter}`}>
+              <a href={`https://x.com/${content.twitter}`}>
                 <Icon name="twitter" />{' '}
                 {content.twitter.startsWith('@')
                   ? content.twitter

--- a/docs/mastering-plone/intro.md
+++ b/docs/mastering-plone/intro.md
@@ -30,7 +30,7 @@ Tell us about yourselves:
 - Tell us, if we speak too fast, too slow or not loud enough.
 - Please give us a sign if you are stuck.
 - Take notes.
-- If you have questions later on, community.plone.org is the Plone forum with many experienced developers.
+- If you have questions later on, https://community.plone.org is the Plone forum with many experienced developers.
 - For coaching, please contact us.  
   See {ref}`trainers<about-trainers-label>` section below.
 

--- a/docs/mastering-plone/registry.md
+++ b/docs/mastering-plone/registry.md
@@ -963,7 +963,7 @@ const TalkView = (props) => {
           {content.twitter && (
             <p>
               Twitter:{' '}
-              <a href={`https://twitter.com/${content.twitter}`}>
+              <a href={`https://x.com/${content.twitter}`}>
                 {content.twitter.startsWith('@')
                   ? content.twitter
                   : '@' + content.twitter}

--- a/docs/mastering-plone/volto_addon.md
+++ b/docs/mastering-plone/volto_addon.md
@@ -24,7 +24,7 @@ For Plone backend add-ons see chapter {ref}`add-ons-label`
 Add-ons enrich a Volto app with specialized blocks, themes, integration of non-Volto Node packages, and more.
 A selection of add-ons can be found on:
 
-- [Awesome Volto](https://github.com/collective/awesome-volto#addons)
+- [Awesome Volto](https://github.com/collective/awesome-volto/blob/main/README.md#addons)
 - [npm #volto-addon](https://www.npmjs.com/search?q=keywords:volto-addon)
 - [github #volto-addon](https://github.com/search?o=desc&q=%23volto-addon&s=&type=Repositories)
 

--- a/docs/mastering-plone/volto_development.md
+++ b/docs/mastering-plone/volto_development.md
@@ -24,7 +24,7 @@ Some of the most used editors in the Plone community are listed here.
 - [VSCode](https://code.visualstudio.com/)
 - [Sublime](https://www.sublimetext.com/)
 - [PyCharm](https://www.jetbrains.com/pycharm/)
-- [Wing IDE](http://wingide.com/)
+- [Wing IDE](https://wingware.com/)
 
 Some features that most editors have in one form or another, are essential when developing with Plone.
 
@@ -65,12 +65,12 @@ Checkout VSCode documentation for topics like [code navigation](https://code.vis
 
 React components can be inspected with `React Developer Tools`: props, hierarchy, and a lot more.
 
-- [React Developer Tools Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)
+- [React Developer Tools Chrome](https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)
 - [React Developer Tools Firefox](https://addons.mozilla.org/de/firefox/addon/react-devtools/)
 
 The Redux store and actions can be inspected with `Redux Developer Tools`.
 
-- [Redux Developer Tools Chrome](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
+- [Redux Developer Tools Chrome](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
 - [Redux Developer Tools Firefox](https://addons.mozilla.org/de/firefox/addon/reduxdevtools/)
 
 

--- a/docs/mastering-plone/volto_overrides.md
+++ b/docs/mastering-plone/volto_overrides.md
@@ -167,7 +167,7 @@ export default NewsItemView;
 
 - The view displays various attributes of the News Item using `content.title`, `content.description` or `content.text.data`.
 
-- You can inspect all data hold by `content` using the React Developer Tools for [Firefox](https://addons.mozilla.org/de/firefox/addon/react-devtools/) or [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi):
+- You can inspect all data hold by `content` using the React Developer Tools for [Firefox](https://addons.mozilla.org/de/firefox/addon/react-devtools/) or [Chrome](https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi):
 
 ```{figure} _static/volto_react_devtools.png
 :align: center

--- a/docs/mastering-plone/volto_talkview.md
+++ b/docs/mastering-plone/volto_talkview.md
@@ -448,7 +448,7 @@ const TalkView = (props) => {
         {content.twitter && (
           <p>
             Twitter:{' '}
-            <a href={`https://twitter.com/${content.twitter}`}>
+            <a href={`https://x.com/${content.twitter}`}>
               {content.twitter.startsWith('@')
                 ? content.twitter
                 : '@' + content.twitter}

--- a/docs/mastering-plone/volto_testing.md
+++ b/docs/mastering-plone/volto_testing.md
@@ -41,7 +41,7 @@ We already added a content type `talk`. Let's write a test 'An editor can add a 
    >   },
    > ```
 
-3. Get some helper functions for an autologin, etc. from [Volto](https://github.com/plone/volto/tree/master/cypress/support).
+3. Get some helper functions for an autologin, etc. from [Volto](https://github.com/plone/volto/tree/main/packages/volto/cypress/support).
 
 4. Create a folder {file}`cypress/integration/` with a file {file}`content.js`
 

--- a/docs/mastering-plone/what_is_plone.md
+++ b/docs/mastering-plone/what_is_plone.md
@@ -142,7 +142,7 @@ Plone creates forms for all these schemata to add and edit content.
 
 ```{seealso}
 - [Zope Component Architecture](https://zopecomponent.readthedocs.io/en/latest/narr.html)
-- The [Keynote](https://youtu.be/eGRJbBI_H2w?t=1308) by Cris Ewing at PyCon 2016
+- The [Keynote](https://www.youtube.com/watch?t=1308&v=eGRJbBI_H2w) by Cris Ewing at PyCon 2016
 ```
 
 

--- a/docs/mastering-plone/what_is_plone.md
+++ b/docs/mastering-plone/what_is_plone.md
@@ -34,7 +34,7 @@ Plone has a multitude of powerful features, is easily accessible to editors, but
 The modular and open component architecture of Plone allows you to change or extend Plone in every aspect!
 
 ```{seealso}
-Plone documentation on [docs.plone.org](https://docs.plone.org/)  
+Plone documentation on [docs.plone.org](https://6.docs.plone.org/)  
 Demo installation on [demo.plone.org](https://demo.plone.org/)
 ```
 

--- a/docs/plone-deployment/project-start.md
+++ b/docs/plone-deployment/project-start.md
@@ -9,7 +9,7 @@ myst:
 
 # Start the Project
 
-The {term}`cookiecutter-plone-starter` equips you with essential tools to initiate a local development environment. The [new project](new-project) offers two methods to launch your project: manually starting the Backend and Frontend servers, or utilizing a Docker Compose stack.
+The {term}`cookiecutter-plone-starter` equips you with essential tools to initiate a local development environment. The {doc}`project-new` offers two methods to launch your project: manually starting the Backend and Frontend servers, or utilizing a Docker Compose stack.
 
 ## Running Local Servers
 

--- a/docs/plone-deployment/setup.md
+++ b/docs/plone-deployment/setup.md
@@ -16,7 +16,7 @@ Ensure a seamless learning experience by preparing your computer with the necess
 ### 1. **Operating System**
 
 - **Linux/macOS:** A recent version is preferred. macOS users should have [Homebrew](https://brew.sh/) installed.
-- **Windows:** Consider using [WSL2 with Ubuntu](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-10), though it’s not officially tested for this training.
+- **Windows:** Consider using [WSL2 with Ubuntu](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/), though it’s not officially tested for this training.
 
 ### 2. **Code Editor**
 
@@ -124,7 +124,7 @@ docker system prune -a
 ```
 
 ```{seealso}
-[docker system prune](https://docs.docker.com/engine/reference/commandline/system_prune/)
+[docker system prune](https://docs.docker.com/reference/cli/docker/system/prune/)
 ```
 
 You can also configure settings for Docker Desktop.

--- a/docs/volto_customization/shadowing.md
+++ b/docs/volto_customization/shadowing.md
@@ -35,6 +35,6 @@ Both paths work fine though, we just want to go all-in with the addon-approach.
 
 ```{seealso}
 - {ref}`voltohandson-header-component-label` (Volto Hands-On Training)
-- {doc}`plone6docs:volto/recipes/customizing-components` (Plone Frontend Documentation)
-- {doc}`plone6docs:volto/recipes/customizing-views` (Plone Frontend Documentation)
+- {doc}`plone6docs:volto/development/customizing-components` (Plone Frontend Documentation)
+- {doc}`plone6docs:volto/development/customizing-views` (Plone Frontend Documentation)
 ```

--- a/docs/volto_customization/voltosettings.md
+++ b/docs/volto_customization/voltosettings.md
@@ -78,7 +78,7 @@ Here are some more setting you might use in your projects:
 - `maxFileUploadSize` - Limit the size of uploads
 - `nonContentRoutes` - A list of path strings which are considered to be outside of plone-restapi's content serialization. For example: `/controlpanel, /login,/sitemap,/personal-information` are all nonContentRoutes.
 
-You can find all existing options in the file <a target="_blank" href="https://github.com/plone/volto/blob/main/src/config/index.js#L73">config/index.js</a> of Volto itself which is available in your projects in `frontend/omelette/src/config/index.js`.
+You can find all existing options in the file <a target="_blank" href="https://github.com/plone/volto/blob/main/packages/volto/src/config/index.js#L73">config/index.js</a> of Volto itself which is available in your projects in `frontend/omelette/src/config/index.js`.
 
 ```{seealso}
 Many options are explained in the {doc}`plone6docs:volto/configuration/settings-reference`

--- a/docs/voltoaddons/02-block-edit.md
+++ b/docs/voltoaddons/02-block-edit.md
@@ -260,7 +260,7 @@ The reducer code looks scary, but it shouldn't be. To understand it, you need
 to know:
 
 - In Volto, all actions that have a `request` field are treated as network
-  requests, and they will be processed by the [API middleware](https://github.com/plone/volto/blob/main/src/middleware/api.js).
+  requests, and they will be processed by the [API middleware](https://github.com/plone/volto/blob/main/packages/volto/src/middleware/api.js).
 - That middleware will then trigger several new actions, derived from the main
   function and prefixed with its name, either `PENDING`, `SUCCESS`, or `FAIL`.
 - For each of these new actions, we will reduce the state of the store to

--- a/docs/voltoaddons/04-block-edit-options.md
+++ b/docs/voltoaddons/04-block-edit-options.md
@@ -438,5 +438,5 @@ export default withBlockDataSource({
 })(DataTableEdit);
 ```
 
-[field.jsx]: https://github.com/plone/volto/blob/main/src/components/manage/Form/Field.jsx
-[Volto's widget documentation]: https://github.com/plone/volto/blob/main/docs/source/recipes/widget.md
+[field.jsx]: https://github.com/plone/volto/blob/main/packages/volto/src/components/manage/Form/Field.jsx
+[Volto's widget documentation]: https://github.com/plone/volto/blob/main/docs/source/development/widget.md

--- a/docs/voltoaddons/about/index.md
+++ b/docs/voltoaddons/about/index.md
@@ -9,8 +9,8 @@ myst:
 
 # About
 
-This training was created by [Tiberiu Ichim](https://twitter.com/ichim_tiberiu)
-in collaboration with [Víctor Fernández de Alba](https://twitter.com/sneridagh).
+This training was created by [Tiberiu Ichim](https://x.com/ichim_tiberiu)
+in collaboration with [Víctor Fernández de Alba](https://x.com/sneridagh).
 
 > I have been a web developer since the turn of the millennium, primarily
 > as a Zope and Plone developer. That didn't stop me from working on projects

--- a/docs/voltohandson/footer.md
+++ b/docs/voltohandson/footer.md
@@ -24,7 +24,7 @@ We also need the `Grid` component from Semantic UI:
 import { Container, List, Grid } from 'semantic-ui-react';
 ```
 
-Then, we replace the `Footer` component content to match the one from plone.org.
+Then, we replace the `Footer` component content to match the one from https://plone.org.
 
 ```jsx
 <div id="footer">
@@ -152,7 +152,7 @@ Then, we replace the `Footer` component content to match the one from plone.org.
                             </UniversalLink>
                           </List.Item>
                           <List.Item>
-                            <UniversalLink href="https://twitter.com/plone">Twitter</UniversalLink>
+                            <UniversalLink href="https://x.com/plone">Twitter</UniversalLink>
                           </List.Item>
                           <List.Item>
                             <UniversalLink href="https://www.instagram.com/plonecms/">

--- a/docs/voltohandson/header.md
+++ b/docs/voltohandson/header.md
@@ -18,7 +18,7 @@ This is a file containing LESS declarations. It's loaded more quickly than the t
 
 ## Some dummy content
 
-So that our Navigation shows more than just the homepage, you should add some dummy pages like on [plone.org](plone.org) to your site using the add page menu in the top left of the page. Add some pages like:
+So that our Navigation shows more than just the homepage, you should add some dummy pages like on [plone.org](https://plone.org) to your site using the add page menu in the top left of the page. Add some pages like:
 
 - Why Plone?
 - Get Started

--- a/docs/voltohandson/internationalization.md
+++ b/docs/voltohandson/internationalization.md
@@ -10,7 +10,7 @@ myst:
 
 # Internationalization
 
-Though plone.org is currently an exception to this, many Plone sites are available in more than one language. For the sake of this training you can make our version of plone.org available in at least another language than english.
+Though https://plone.org/ is currently an exception to this, many Plone sites are available in more than one language. For the sake of this training you can make our version of https://plone.org/ available in at least another language than english.
 
 ## Set up site to be multilingual
 

--- a/docs/voltohandson/introtoblocks.md
+++ b/docs/voltohandson/introtoblocks.md
@@ -39,7 +39,7 @@ There you can choose a content type to edit and enable `Blocks` in the `Behavior
 
 ## Blocks anatomy
 
-The first Block we will create is the Slider Block at the top of the plone.org frontpage.
+The first Block we will create is the Slider Block at the top of the https://plone.org frontpage.
 
 ```{image} _static/slider_screenshot.png
 :align: center

--- a/docs/voltohandson/introtoblocks.md
+++ b/docs/voltohandson/introtoblocks.md
@@ -28,7 +28,7 @@ However, the `plone.volto` package, which comes with a default Plone 6 site enab
 ## How to manually enable Blocks on a content type
 
 There is a behavior called `Blocks` made available by `plone.volto`.
-To enable it you need to access the types [controlpanel](localhost:3000/controlpanel/dexterity-types).
+To enable it you need to access the types [control panel](http://localhost:3000/controlpanel/dexterity-types).
 
 There you can choose a content type to edit and enable `Blocks` in the `Behaviors` tab.
 

--- a/docs/voltohandson/plonereleasetype.md
+++ b/docs/voltohandson/plonereleasetype.md
@@ -9,7 +9,7 @@ myst:
 
 # Plone Release content type
 
-On plone.org we have a custom content type called "Plone Release". For the training you will recreate that content type and write a custom view for it.
+On https://plone.org/ we have a custom content type called "Plone Release". For the training you will recreate that content type and write a custom view for it.
 
 Create the content type by going to the [content types control panel](http://localhost:3000/controlpanel/dexterity-types) of your app and adding a new content type called "Plone Release". Next amend the schema of that type by clicking on the three dots behind "Plone Release in the Types overview and choosing schema.
 Add the following fields to the schema:

--- a/docs/voltohandson/releaseblock.md
+++ b/docs/voltohandson/releaseblock.md
@@ -196,7 +196,7 @@ export default ReleaseView;
 
 Note that all the fields defined in the schema and filled via the sidebar can now be accessed from the `data` key of the blocks props. You can use `console.log(data)` to see the details.
 
-To make the block look like its twin on plone.org we only need to add the following CSS to our `custom.overrides`:
+To make the block look like its twin on https://plone.org, we only need to add the following CSS to our `custom.overrides`:
 
 ```less
 // Release block

--- a/docs/voltohandson/starttheming.md
+++ b/docs/voltohandson/starttheming.md
@@ -25,7 +25,7 @@ Finally edit your `theme.config` and change the `@siteFolder` variable to contai
 
 ## Basic font family
 
-[plone.org](plone.org) uses the "Assistant" font instead of the Volto default "Poppins". You can use Semantic UI variables for customizing the font, as it's a valuable feature.
+[plone.org](https://plone.org) uses the "Assistant" font instead of the Volto default "Poppins". You can use Semantic UI variables for customizing the font, as it's a valuable feature.
 
 Create a file called `site.variables`in the following path `src/addons/<your-addon-name>/theme/globals/`.
 

--- a/docs/voltohandson/starttheming.md
+++ b/docs/voltohandson/starttheming.md
@@ -50,7 +50,7 @@ you should define it as usual in CSS and set the variable `importGoogleFonts` ap
 @importGoogleFonts: true;
 ```
 
-Two more important variables that are changed in plone.org are:
+Two more important variables that are changed in https://plone.org/ are:
 
 ```less
 @largeMonitorBreakpoint: 1330px;


### PR DESCRIPTION
Opsworks was EOL on May 26, 2024. See https://aws.amazon.com/blogs/mt/seamlessly-off-board-from-aws-opsworks-stacks-by-detaching-resources/