### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/mastering-plone/dexterity.md
+++ b/docs/mastering-plone/dexterity.md
@@ -88,7 +88,7 @@ They are meant to be used across content types to add shared functionality.
 
 One example is the ability of most content types to allow them to be excluded from the navigation.
 The field is available on all types even though it is not defined in their schema.
-Instead is is provided by the behavior `plone.excludefromnavigation` that most content types use.
+Instead it is provided by the behavior `plone.excludefromnavigation` that most content types use.
 
 Each behavior schema can define fields. The values of these fields are again attributes on content objects.
 

--- a/docs/mastering-plone/relations.md
+++ b/docs/mastering-plone/relations.md
@@ -152,7 +152,7 @@ Setting the mode of the widget to `search` makes it easier to select from the co
 
 The problem is that in the default mode of the Related Items wisget items that are in container s are not shown unless you add thes types of contaibers to the query.
 
-Therefore is is recommended to use CatalogSource only in in `search` mode.
+Therefore it is recommended to use CatalogSource only in in `search` mode.
 
 ```{code-block} python
 :emphasize-lines: 10


### PR DESCRIPTION
Fixes #843 issue.

Fixed typos.

I, Faakhir30, agree to have this contribution published under Creative Commons 4.0 International License (CC BY 4.0), with attribution to the Plone Foundation.