### PR TITLE
change vlt version from alpha.1 to alpha.2

### DIFF
--- a/docs/customizing-volto-light-theme/installing-vlt.md
+++ b/docs/customizing-volto-light-theme/installing-vlt.md
@@ -1,10 +1,10 @@
 ---
 myst:
   html_meta:
-    'description': 'Installing Volto Light Theme'
-    'property=og:description': 'Installing Volto Light Theme'
-    'property=og:title': 'Installing Volto Light Theme'
-    'keywords': 'Plone, Volto, Training, Volto Light Theme'
+    "description": "Installing Volto Light Theme"
+    "property=og:description": "Installing Volto Light Theme"
+    "property=og:title": "Installing Volto Light Theme"
+    "keywords": "Plone, Volto, Training, Volto Light Theme"
 ---
 
 # Installing Volto Light Theme

--- a/docs/customizing-volto-light-theme/installing-vlt.md
+++ b/docs/customizing-volto-light-theme/installing-vlt.md
@@ -1,12 +1,11 @@
 ---
 myst:
   html_meta:
-    "description": "Installing Volto Light Theme"
-    "property=og:description": "Installing Volto Light Theme"
-    "property=og:title": "Installing Volto Light Theme"
-    "keywords": "Plone, Volto, Training, Volto Light Theme"
+    'description': 'Installing Volto Light Theme'
+    'property=og:description': 'Installing Volto Light Theme'
+    'property=og:title': 'Installing Volto Light Theme'
+    'keywords': 'Plone, Volto, Training, Volto Light Theme'
 ---
-
 
 # Installing Volto Light Theme
 
@@ -21,7 +20,7 @@ For now we'll be using an `alpha` release, so we need to specify the correct ver
 ```
 
 ```shell
-pnpm install @kitconcept/volto-light-theme@6.0.0-alpha.1
+pnpm install @kitconcept/volto-light-theme@6.0.0-alpha.2
 ```
 
 While in your project package folder, add VLT to the `addons` list in your {file}`package.json`, as follows:


### PR DESCRIPTION
alpha.1 doesn't work correctly when adding the Image block.

<!-- readthedocs-preview plone-training start -->
----
📚 Documentation preview 📚: https://plone-training--889.org.readthedocs.build/

<!-- readthedocs-preview plone-training end -->