### PR TITLE
Add a cross-reference to Plone 6 Documentation to the primary navigation

### DIFF
--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -1,0 +1,12 @@
+---
+myst:
+  html_meta:
+    "description": "Plone 6 Documentation"
+    "property=og:description": "Plone 6 Documentation"
+    "property=og:title": "Plone 6 Documentation"
+    "keywords": "Plone, Documentation"
+---
+
+# Plone 6 Documentation
+
+See {doc}`plone6docs:index`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,13 @@ contributing/index
 teaching/index
 ```
 
+```{toctree}
+:caption: Plone 6 Documentation
+:maxdepth: 1
+:hidden: true
+
+documentation/index
+```
 
 ## Development and Customization
 


### PR DESCRIPTION
See https://github.com/plone/documentation/pull/1801

<!-- readthedocs-preview plone-training start -->
----
📚 Documentation preview 📚: https://plone-training--894.org.readthedocs.build/

<!-- readthedocs-preview plone-training end -->