### PR TITLE
Update deploy.md log Commands

### DIFF
--- a/docs/plone-deployment/deploy.md
+++ b/docs/plone-deployment/deploy.md
@@ -70,9 +70,10 @@ make stack-create-site
 
 Monitor the logs of each service with these commands:
 
--   Traefik: `make logs-webserver`
--   Frontend: `make logs-frontend`
--   Backend: `make logs-backend`
+-   Traefik: `make stack-logs-webserver`
+-   Frontend: `make stack-logs-frontend`
+-   Backend: `make stack-logs-backend`
+-   Backend: `make stack-logs-db`
 
 ## Automating Deployment with GitHub Actions
 


### PR DESCRIPTION
the log monitoring commans are not correct anymore. Montoring Logs Makefile commands in devops now have a `stack-` prefix and another ` make stack-logs-db` is available in setups created by cookieplone 0.8.2 using Plone 6.0.14, Volto 18.7.0.