### PR TITLE
Update index.md add another QuickLink for HowTo Suggest edit

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -52,6 +52,13 @@ Any method below is acceptable, but are listed in order of most likely to get a 
 As a convenience, at the top right of every page, there is a GitHub navigation menu.
 Tap, click, or hover over the GitHub Octocat icon for options.
 
+```{tip}
+_misused for suggestion_
+**Please** add a fourth option in the following menu and description:
+"HowTo Quick Link for **Suggest edit**"
+full Tool-Type Text: Link to our Docs for using "Suggest edit" HowTo if you have already signed a Contributor Agreement.
+```
+
 ```{image} _static/github-navigation.png
 :alt: GitHub navigation menu 
 ```


### PR DESCRIPTION
**Please** add a fourth option in the following menu and description: "HowTo Quick Link for **Suggest edit**"
full Tool-Type Text: Link to our Docs for using "Suggest edit" HowTo if you have already signed a Contributor Agreement.

See placeholder copy in the request. No actual code change added!

<!-- readthedocs-preview plone-training start -->
----
📚 Documentation preview 📚: https://plone-training--922.org.readthedocs.build/

<!-- readthedocs-preview plone-training end -->