### PR TITLE
Add support for tooltips, `attrs_block`, `attrs_inline`, and `striket…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,17 +62,21 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_sitemap",
+    "sphinx_tippy",
     "sphinxext.opengraph",
 ]
 
 # For more information see:
 # https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
 myst_enable_extensions = [
-    "deflist",  # You will be able to utilise definition lists
-    # https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#definition-lists
-    "linkify",  # Identify “bare” web URLs and add hyperlinks.
-    "colon_fence",  # You can also use ::: delimiters to denote code fences,\
-    #  instead of ```.
+    "attrs_block",  # Support parsing of block attributes.
+    "attrs_inline",  # Support parsing of inline attributes.
+    "colon_fence",  # You can also use ::: delimiters to denote code fences, instead of ```.
+    "deflist",  # Support definition lists. https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#definition-lists
+    "html_image",  # For inline images. See https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#html-images
+    "linkify",  # Identify "bare" web URLs and add hyperlinks.
+    "strikethrough",  # See https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#syntax-strikethrough
+    "substitution",  # Use Jinja2 for substitutions. https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#substitutions-with-jinja2
 ]
 
 # If true, the Docutils Smart Quotes transform, originally based on SmartyPants
@@ -277,6 +281,16 @@ ogp_custom_meta_tags = [
 
 # -- sphinx.ext.todo -----------------------
 todo_include_todos = True  # Uncomment to show todos.
+
+
+# -- sphinx-tippy configuration ----------------------------------
+tippy_anchor_parent_selector = "article.bd-article"
+tippy_enable_doitips = False
+tippy_enable_wikitips = False
+tippy_props = {
+    "interactive": True,
+    "placement": "auto-end",
+}
 
 
 # An extension that allows replacements for code blocks that

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ sphinx-book-theme
 sphinx-copybutton
 sphinx-design
 sphinx-sitemap
+sphinx-tippy
 sphinx-togglebutton
 sphinxcontrib-spelling
 sphinxext-opengraph


### PR DESCRIPTION
…hrough`

- Add support for tooltips, `attrs_block`, `attrs_inline`, and `strikethrough`
- Closes #540

<!-- readthedocs-preview plone-training start -->
----
📚 Documentation preview 📚: https://plone-training--933.org.readthedocs.build/

<!-- readthedocs-preview plone-training end -->