### PR TITLE
Update index.md change term Teaching to Giving a Training

### DIFF
--- a/docs/teaching/index.md
+++ b/docs/teaching/index.md
@@ -9,9 +9,9 @@ myst:
 
 (teaching-index-label)=
 
-# Teaching
+# Giving a Training
 
-This section covers all that trainers need to know when teaching Plone Trainings.
+This section covers all that trainers need to know when giving Plone Trainings.
 
 Trainers should read {doc}`/contributing/setup-build`.
 These documents help trainers prepare for a successful training experience.


### PR DESCRIPTION
Teaching implies a in my opinion outdated understanding of top down education. Some think they cannot teach. Some hate teachers. The actual content of that pages reflect a more modern  aproach and are more inviting. This should be also present in the wording of the TOC and Headlines.

The content can also be improved to a more encouraging onboarding of trainers beyond it is already trying this.

<!-- readthedocs-preview plone-training start -->
----
📚 Documentation preview 📚: https://plone-training--934.org.readthedocs.build/

<!-- readthedocs-preview plone-training end -->