### PR TITLE
Corrected the component's spelling while exporting it in plonereleasetype.md file

### DIFF
--- a/docs/voltohandson/plonereleasetype.md
+++ b/docs/voltohandson/plonereleasetype.md
@@ -34,7 +34,7 @@ return(
 )
 }
 
-export default PlonereleaseView;
+export default PloneReleaseView;
 ```
 
 Import and export this file in `components/index.js` to make it easier accessible throughout the project:


### PR DESCRIPTION
Corrected the component spelling while exporting it . 
Component was PloneReleaseView , and while exporting it was written as PlonereleaseView.
I simply corrected the spelling in the export default line.
To save user's time from debugging small errors .

<!-- readthedocs-preview plone-training start -->
----
📚 Documentation preview 📚: https://plone-training--936.org.readthedocs.build/

<!-- readthedocs-preview plone-training end -->