### PR TITLE
Corrected the filename which was to be updated in the internationaliz…

### DIFF
--- a/docs/voltohandson/internationalization.md
+++ b/docs/voltohandson/internationalization.md
@@ -33,7 +33,7 @@ And finally set up the folder structure to contain translated strings. Inside of
 
 ## Adding first translatable strings
 
-The first parts of the site to translate would be the ones from the "Plone release" content type, you just created. Go to the `plonerelease.jsx` file and import the following at the top: `import { FormattedMessage } from 'react-intl';`
+The first parts of the site to translate would be the ones from the "Plone release" content type, you just created. Go to the `PloneReleaseView.jsx` file and import the following at the top: `import { FormattedMessage } from 'react-intl';`
 
 To translate a static string replace it with the `<FormattedMessage/>` component like this:
 


### PR DESCRIPTION
…ation part of Volto-hands-on training

In the internationalisation part of the Volto hands on training,we have to first translate the Plone release content type of our site.  The file to be updated is PloneReleaseView.jsx , but the training documentation says the file to be updated is plonerelease.jsx , which we never created in past.

I corrected the file which should be updated-- (PloneReleaseView.jsx ,and not the non existent plonerelease.jsx)

This can cause confusion to a new developer, and he might create a plonerelease.jsx which technically was PloneReleaseView.jsx .