### PR TITLE
Addon is specified in package.json, not in project.json

### DIFF
--- a/docs/voltoaddons/01-addon-basics.md
+++ b/docs/voltoaddons/01-addon-basics.md
@@ -282,7 +282,7 @@ enabling the project to override any configuration.
 So: {guilabel}`Volto → add-ons → project`.
 
 To load an add-on, the project needs to specify the add-on in the `addons` key
-of `project.json`. Optional configuration loaders are specified as
+of `package.json`. Optional configuration loaders are specified as
 a comma-separated list after the `:` colon symbol.
 
 ```js


### PR DESCRIPTION
To load an add-on, the project needs to specify the add-on in the addons key of package.json of main project.
 In the training  it was written project.json, I corrected it to package.json.


<!-- readthedocs-preview plone-training start -->
----
📚 Documentation preview 📚: https://plone-training--939.org.readthedocs.build/

<!-- readthedocs-preview plone-training end -->